### PR TITLE
feat(mcp): add workspace theme management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Codex should: `list_datasources` → `create_app` → `lint_app_spec` → `apply
 | `add_events(...)` / `add_query_lifecycles(...)` | Add arbitrary interactions or expand standard mutation success/failure flows in one batch |
 | `update_*` / confirmed `delete_*` / `run_query(...)` | Repair apps in place; require exact-target confirmation for deletion and explicit approval for large/billable reads |
 
+Workspace theme creation and management are exposed through `manage_theme`; applying a theme to an app remains part
+of `update_app_settings`. The definition structure and token-backed styling guidance are documented in
+[`docs/theme-api-tool.md`](docs/theme-api-tool.md).
+
 ## Development
 
 ```bash

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -35010,6 +35010,41 @@ function createClient(auth, config2) {
       throw new Error("ToolJet listAppThemes failed: expected an array response.");
     return body;
   }
+  async function createAppTheme(params) {
+    const res = await auth.authedFetch("/api/themes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: params.name,
+        organizationId: await auth.getOrganizationId(),
+        definition: params.definition,
+        isDefault: params.isDefault ?? false
+      })
+    });
+    await assertOk(res, "createAppTheme");
+    return await res.json();
+  }
+  async function updateAppTheme(themeId, field, body, operation) {
+    const res = await auth.authedFetch(`/api/themes/${encodeURIComponent(themeId)}/${field}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    await assertOk(res, operation);
+  }
+  async function setDefaultAppTheme(themeId, isDefault) {
+    await updateAppTheme(themeId, "default", { isDefault }, "setDefaultAppTheme");
+  }
+  async function updateAppThemeDefinition(themeId, definition) {
+    await updateAppTheme(themeId, "definition", { definition }, "updateAppThemeDefinition");
+  }
+  async function renameAppTheme(themeId, name) {
+    await updateAppTheme(themeId, "name", { name }, "renameAppTheme");
+  }
+  async function deleteAppTheme(themeId) {
+    const res = await auth.authedFetch(`/api/themes/${encodeURIComponent(themeId)}`, { method: "DELETE" });
+    await assertOk(res, "deleteAppTheme");
+  }
   async function updateAppSettings(params) {
     const body = {
       ...params.globalSettings ? { globalSettings: params.globalSettings } : {},
@@ -35840,6 +35875,11 @@ function createClient(auth, config2) {
     getAppSummary,
     getAppSettings,
     listAppThemes,
+    createAppTheme,
+    setDefaultAppTheme,
+    updateAppThemeDefinition,
+    renameAppTheme,
+    deleteAppTheme,
     updateAppSettings,
     getComponent,
     createPage,
@@ -41497,6 +41537,122 @@ function getRuntimeInfoTool(runtime) {
   };
 }
 
+// dist/tools/manageTheme.js
+var colorPair = external_exports.object({
+  light: external_exports.string().trim().min(1).max(100).describe("Color used in light mode; hex is recommended."),
+  dark: external_exports.string().trim().min(1).max(100).describe("Color used in dark mode; hex is recommended.")
+}).strict();
+var themeDefinition = external_exports.object({
+  brand: external_exports.object({
+    colors: external_exports.object({
+      primary: colorPair,
+      secondary: colorPair.optional(),
+      tertiary: colorPair.optional()
+    }).strict()
+  }).strict(),
+  text: external_exports.object({
+    font: external_exports.string().trim().min(1).max(200),
+    colors: external_exports.object({
+      primary: colorPair,
+      placeholder: colorPair.optional(),
+      disabled: colorPair.optional()
+    }).strict()
+  }).strict(),
+  border: external_exports.object({
+    radius: external_exports.object({
+      default: external_exports.number().nonnegative(),
+      small: external_exports.number().nonnegative(),
+      large: external_exports.number().nonnegative()
+    }).strict(),
+    colors: external_exports.object({
+      default: colorPair,
+      weak: colorPair.optional(),
+      disabled: colorPair.optional()
+    }).strict()
+  }).strict(),
+  systemStatus: external_exports.object({
+    colors: external_exports.object({
+      success: colorPair,
+      error: colorPair.optional(),
+      warning: colorPair.optional()
+    }).strict()
+  }).strict(),
+  surface: external_exports.object({
+    colors: external_exports.object({
+      appBackground: colorPair,
+      surface1: colorPair,
+      surface2: colorPair,
+      surface3: colorPair
+    }).strict()
+  }).strict()
+}).strict();
+function requireValue(value, label) {
+  if (value === void 0)
+    throw new Error(`manage_theme requires ${label} for this action.`);
+  return value;
+}
+async function readTheme(client, themeId) {
+  const theme = (await client.listAppThemes()).find((candidate) => candidate.id === themeId);
+  if (!theme)
+    throw new Error(`Theme "${themeId}" is not available in the active workspace.`);
+  return theme;
+}
+function manageThemeTool(client) {
+  return {
+    name: "manage_theme",
+    description: "Manage workspace theme objects through ToolJet's typed theme API. Actions: list, create, set_default, update_definition, rename, delete. Definitions contain brand, text, border, systemStatus, and surface tokens with light/dark values. Creating a theme does not apply it to an app; use update_app_settings(theme_id) for that. Delete requires confirm:true after exact-target approval.",
+    inputSchema: {
+      action: external_exports.enum(["list", "create", "set_default", "update_definition", "rename", "delete"]),
+      theme_id: external_exports.string().uuid().optional(),
+      name: external_exports.string().trim().min(1).max(100).optional(),
+      definition: themeDefinition.optional(),
+      is_default: external_exports.boolean().optional(),
+      confirm: external_exports.boolean().optional()
+    },
+    async handler(args) {
+      try {
+        if (args.action === "list") {
+          return ok({ themes: await client.listAppThemes() });
+        }
+        if (args.action === "create") {
+          const name = requireValue(args.name, "name");
+          if (name.length < 5)
+            throw new Error("Theme name must contain at least 5 characters.");
+          if (name === "ToolJet")
+            throw new Error('The reserved theme name "ToolJet" cannot be used.');
+          const created = await client.createAppTheme({
+            name,
+            definition: requireValue(args.definition, "definition"),
+            isDefault: args.is_default ?? false
+          });
+          return ok({ theme: created });
+        }
+        const themeId = requireValue(args.theme_id, "theme_id");
+        await readTheme(client, themeId);
+        if (args.action === "set_default") {
+          await client.setDefaultAppTheme(themeId, args.is_default ?? true);
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+        if (args.action === "update_definition") {
+          await client.updateAppThemeDefinition(themeId, requireValue(args.definition, "definition"));
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+        if (args.action === "rename") {
+          await client.renameAppTheme(themeId, requireValue(args.name, "name"));
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+        if (args.confirm !== true) {
+          throw new Error(`Deleting theme "${themeId}" requires confirm:true after exact-target user approval.`);
+        }
+        await client.deleteAppTheme(themeId);
+        return ok({ deleted: true, theme_id: themeId });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+
 // dist/tools/index.js
 var LEGACY_SINGULAR_CREATE_TOOL_NAMES = /* @__PURE__ */ new Set([
   "create_table",
@@ -41558,7 +41714,8 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     addQueryLifecyclesTool(client),
     listEventsTool(client),
     updateEventsTool(client),
-    deleteEventTool(client)
+    deleteEventTool(client),
+    manageThemeTool(client)
   ];
   const exposedTools = includeLegacySingularCreateTools() ? tools : tools.filter((tool) => !LEGACY_SINGULAR_CREATE_TOOL_NAMES.has(tool.name));
   for (const tool of exposedTools) {

--- a/docs/theme-api-tool.md
+++ b/docs/theme-api-tool.md
@@ -1,0 +1,69 @@
+# ToolJet theme API
+
+Use `manage_theme` to manage workspace theme objects. The available actions are `list`, `create`, `set_default`,
+`update_definition`, `rename`, and `delete`. Theme deletion requires `confirm:true` after the user approves the
+exact theme. ToolJet still enforces the active workspace, permissions, validation, and license gates.
+
+Creating a workspace theme does not apply it to an app. After creating or selecting a theme, call
+`update_app_settings({ app_id, version_id, theme_id })` to apply it to that app's current editing version.
+
+## Theme definition
+
+A theme definition uses literal values and follows this structure:
+
+```text
+brand.colors
+  primary:   { light, dark }
+  secondary: { light, dark }  # optional
+  tertiary:  { light, dark }  # optional
+
+text
+  font
+  colors.primary:     { light, dark }
+  colors.placeholder: { light, dark }  # optional
+  colors.disabled:    { light, dark }  # optional
+
+border
+  radius: { default, small, large }
+  colors.default:  { light, dark }
+  colors.weak:     { light, dark }  # optional
+  colors.disabled: { light, dark }  # optional
+
+systemStatus.colors
+  success: { light, dark }
+  error:   { light, dark }  # optional
+  warning: { light, dark }  # optional
+
+surface.colors
+  appBackground: { light, dark }
+  surface1:      { light, dark }
+  surface2:      { light, dark }
+  surface3:      { light, dark }
+```
+
+Theme colors are normally hex values. The saved definition generates ToolJet's semantic `--cc-*` variables at
+runtime; do not put CSS variable references inside the theme definition itself.
+
+## Styling components with a selected theme
+
+Themes are optional. Do not create a theme, change the workspace default, or replace an app's selected theme unless
+the user asks for it.
+
+When an app has a selected theme, preserve token-backed component defaults and use existing semantic variables for
+repeated visual roles. Common tokens include:
+
+- `var(--cc-primary-brand)`
+- `var(--cc-primary-text)`
+- `var(--cc-placeholder-text)`
+- `var(--cc-default-border)`
+- `var(--cc-weak-border)`
+- `var(--cc-error-systemStatus)`
+- `var(--cc-appBackground-surface)`
+- `var(--cc-surface1-surface)`
+
+Pass these as raw style values, for example
+`styles.backgroundColor.value = "var(--cc-surface1-surface)"`; do not wrap them in `{{...}}` and do not invent
+token names. Literal hex or RGB values remain appropriate for deliberate one-off accents, chart series, or contrast
+corrections when no semantic token fits. Repeated foundational colors should remain token-backed so theme and
+light/dark changes continue to propagate.
+

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -45,6 +45,7 @@ for (const f of [
   'references/security.md',
   'references/qa.md',
   'references/components.md',
+  'references/themes.md',
   'scripts/browser-audit.js',
 ]) {
   if (!existsSync(resolve(root, 'skills/tooljet-app-builder', f))) {

--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -782,6 +782,7 @@ const qa = makeReference(
   'Read this when a page or primary flow is ready to verify. It defines the bounded static, runtime, and visual checks required before claiming the work is complete.',
   routedSections.qa
 );
+const themeApi = readFileSync(resolve(root, 'docs/theme-api-tool.md'), 'utf8');
 const generalComponentRules = componentRuleSections
   .filter((section) => !['Table', 'Form'].includes(section.publishedName))
   .map((section) => section.markdown)
@@ -829,6 +830,7 @@ If an expected source is absent or a query returns a connection failure, explain
 - \`references/security.md\` — authorization boundaries, current-user variables, permissions, and sensitive/destructive operations.
 - \`references/qa.md\` — static checks, safe runtime checks, the browser audit, triage, and confirmation.
 - \`references/components.md\` — selective component palette and exact binding/rendering rules not covered by Table/Form references.
+- \`references/themes.md\` — workspace theme creation and management, the exact theme definition structure, app assignment, and token-backed component styling.
 
 Tool schemas, catalog responses, and returned warnings are authoritative. Do not preload every reference. Keep inspection results bounded: use \`get_app_summary\`'s structural default or exact field projections, and request \`detail:"full"\` only after narrowing the target. Reuse earlier catalog, schema, and summary results instead of repeating the same read.
 
@@ -851,6 +853,7 @@ const references = {
   'security.md': security,
   'qa.md': qa,
   'components.md': components,
+  'themes.md': themeApi,
 };
 
 const hostSkillRoots = [

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -39,6 +39,7 @@ If an expected source is absent or a query returns a connection failure, explain
 - `references/security.md` — authorization boundaries, current-user variables, permissions, and sensitive/destructive operations.
 - `references/qa.md` — static checks, safe runtime checks, the browser audit, triage, and confirmation.
 - `references/components.md` — selective component palette and exact binding/rendering rules not covered by Table/Form references.
+- `references/themes.md` — workspace theme creation and management, the exact theme definition structure, app assignment, and token-backed component styling.
 
 Tool schemas, catalog responses, and returned warnings are authoritative. Do not preload every reference. Keep inspection results bounded: use `get_app_summary`'s structural default or exact field projections, and request `detail:"full"` only after narrowing the target. Reuse earlier catalog, schema, and summary results instead of repeating the same read.
 

--- a/skill/references/themes.md
+++ b/skill/references/themes.md
@@ -1,0 +1,69 @@
+# ToolJet theme API
+
+Use `manage_theme` to manage workspace theme objects. The available actions are `list`, `create`, `set_default`,
+`update_definition`, `rename`, and `delete`. Theme deletion requires `confirm:true` after the user approves the
+exact theme. ToolJet still enforces the active workspace, permissions, validation, and license gates.
+
+Creating a workspace theme does not apply it to an app. After creating or selecting a theme, call
+`update_app_settings({ app_id, version_id, theme_id })` to apply it to that app's current editing version.
+
+## Theme definition
+
+A theme definition uses literal values and follows this structure:
+
+```text
+brand.colors
+  primary:   { light, dark }
+  secondary: { light, dark }  # optional
+  tertiary:  { light, dark }  # optional
+
+text
+  font
+  colors.primary:     { light, dark }
+  colors.placeholder: { light, dark }  # optional
+  colors.disabled:    { light, dark }  # optional
+
+border
+  radius: { default, small, large }
+  colors.default:  { light, dark }
+  colors.weak:     { light, dark }  # optional
+  colors.disabled: { light, dark }  # optional
+
+systemStatus.colors
+  success: { light, dark }
+  error:   { light, dark }  # optional
+  warning: { light, dark }  # optional
+
+surface.colors
+  appBackground: { light, dark }
+  surface1:      { light, dark }
+  surface2:      { light, dark }
+  surface3:      { light, dark }
+```
+
+Theme colors are normally hex values. The saved definition generates ToolJet's semantic `--cc-*` variables at
+runtime; do not put CSS variable references inside the theme definition itself.
+
+## Styling components with a selected theme
+
+Themes are optional. Do not create a theme, change the workspace default, or replace an app's selected theme unless
+the user asks for it.
+
+When an app has a selected theme, preserve token-backed component defaults and use existing semantic variables for
+repeated visual roles. Common tokens include:
+
+- `var(--cc-primary-brand)`
+- `var(--cc-primary-text)`
+- `var(--cc-placeholder-text)`
+- `var(--cc-default-border)`
+- `var(--cc-weak-border)`
+- `var(--cc-error-systemStatus)`
+- `var(--cc-appBackground-surface)`
+- `var(--cc-surface1-surface)`
+
+Pass these as raw style values, for example
+`styles.backgroundColor.value = "var(--cc-surface1-surface)"`; do not wrap them in `{{...}}` and do not invent
+token names. Literal hex or RGB values remain appropriate for deliberate one-off accents, chart series, or contrast
+corrections when no semantic token fits. Repeated foundational colors should remain token-backed so theme and
+light/dark changes continue to propagate.
+

--- a/skills/tooljet-app-builder/SKILL.md
+++ b/skills/tooljet-app-builder/SKILL.md
@@ -39,6 +39,7 @@ If an expected source is absent or a query returns a connection failure, explain
 - `references/security.md` — authorization boundaries, current-user variables, permissions, and sensitive/destructive operations.
 - `references/qa.md` — static checks, safe runtime checks, the browser audit, triage, and confirmation.
 - `references/components.md` — selective component palette and exact binding/rendering rules not covered by Table/Form references.
+- `references/themes.md` — workspace theme creation and management, the exact theme definition structure, app assignment, and token-backed component styling.
 
 Tool schemas, catalog responses, and returned warnings are authoritative. Do not preload every reference. Keep inspection results bounded: use `get_app_summary`'s structural default or exact field projections, and request `detail:"full"` only after narrowing the target. Reuse earlier catalog, schema, and summary results instead of repeating the same read.
 

--- a/skills/tooljet-app-builder/references/themes.md
+++ b/skills/tooljet-app-builder/references/themes.md
@@ -1,0 +1,69 @@
+# ToolJet theme API
+
+Use `manage_theme` to manage workspace theme objects. The available actions are `list`, `create`, `set_default`,
+`update_definition`, `rename`, and `delete`. Theme deletion requires `confirm:true` after the user approves the
+exact theme. ToolJet still enforces the active workspace, permissions, validation, and license gates.
+
+Creating a workspace theme does not apply it to an app. After creating or selecting a theme, call
+`update_app_settings({ app_id, version_id, theme_id })` to apply it to that app's current editing version.
+
+## Theme definition
+
+A theme definition uses literal values and follows this structure:
+
+```text
+brand.colors
+  primary:   { light, dark }
+  secondary: { light, dark }  # optional
+  tertiary:  { light, dark }  # optional
+
+text
+  font
+  colors.primary:     { light, dark }
+  colors.placeholder: { light, dark }  # optional
+  colors.disabled:    { light, dark }  # optional
+
+border
+  radius: { default, small, large }
+  colors.default:  { light, dark }
+  colors.weak:     { light, dark }  # optional
+  colors.disabled: { light, dark }  # optional
+
+systemStatus.colors
+  success: { light, dark }
+  error:   { light, dark }  # optional
+  warning: { light, dark }  # optional
+
+surface.colors
+  appBackground: { light, dark }
+  surface1:      { light, dark }
+  surface2:      { light, dark }
+  surface3:      { light, dark }
+```
+
+Theme colors are normally hex values. The saved definition generates ToolJet's semantic `--cc-*` variables at
+runtime; do not put CSS variable references inside the theme definition itself.
+
+## Styling components with a selected theme
+
+Themes are optional. Do not create a theme, change the workspace default, or replace an app's selected theme unless
+the user asks for it.
+
+When an app has a selected theme, preserve token-backed component defaults and use existing semantic variables for
+repeated visual roles. Common tokens include:
+
+- `var(--cc-primary-brand)`
+- `var(--cc-primary-text)`
+- `var(--cc-placeholder-text)`
+- `var(--cc-default-border)`
+- `var(--cc-weak-border)`
+- `var(--cc-error-systemStatus)`
+- `var(--cc-appBackground-surface)`
+- `var(--cc-surface1-surface)`
+
+Pass these as raw style values, for example
+`styles.backgroundColor.value = "var(--cc-surface1-surface)"`; do not wrap them in `{{...}}` and do not invent
+token names. Literal hex or RGB values remain appropriate for deliberate one-off accents, chart series, or contrast
+corrections when no semantic token fits. Repeated foundational colors should remain token-backed so theme and
+light/dark changes continue to propagate.
+

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -33,6 +33,12 @@ export interface AppTheme {
   [key: string]: unknown;
 }
 
+export interface CreateAppThemeParams {
+  name: string;
+  definition: Record<string, unknown>;
+  isDefault?: boolean;
+}
+
 export interface AppSettingsSnapshot {
   app_id: string;
   version_id: string;
@@ -384,6 +390,11 @@ export interface ToolJetClient {
   getAppSummary(appId: string): Promise<AppSummary>;
   getAppSettings(appId: string, versionId: string): Promise<AppSettingsSnapshot>;
   listAppThemes(): Promise<AppTheme[]>;
+  createAppTheme(params: CreateAppThemeParams): Promise<AppTheme>;
+  setDefaultAppTheme(themeId: string, isDefault: boolean): Promise<void>;
+  updateAppThemeDefinition(themeId: string, definition: Record<string, unknown>): Promise<void>;
+  renameAppTheme(themeId: string, name: string): Promise<void>;
+  deleteAppTheme(themeId: string): Promise<void>;
   updateAppSettings(params: UpdateAppSettingsParams): Promise<void>;
   getComponent(appId: string, componentId: string): Promise<ComponentSummary & { page_id: string }>;
   createPage(params: CreatePageParams): Promise<CreatePageResult>;
@@ -550,6 +561,7 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   const datasourceManagementUrl = (workspaceSlug: string, datasourceId?: string) =>
     `${config.appUrl}/${encodeURIComponent(workspaceSlug)}/data-sources` +
     (datasourceId ? `/${encodeURIComponent(datasourceId)}` : '');
+
   async function getApp(appId: string): Promise<any> {
     const res = await auth.authedFetch(`/api/apps/${appId}`);
     await assertOk(res, 'getApp');
@@ -634,6 +646,52 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     const body = await res.json();
     if (!Array.isArray(body)) throw new Error('ToolJet listAppThemes failed: expected an array response.');
     return body as AppTheme[];
+  }
+
+  async function createAppTheme(params: CreateAppThemeParams): Promise<AppTheme> {
+    const res = await auth.authedFetch('/api/themes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: params.name,
+        organizationId: await auth.getOrganizationId(),
+        definition: params.definition,
+        isDefault: params.isDefault ?? false,
+      }),
+    });
+    await assertOk(res, 'createAppTheme');
+    return (await res.json()) as AppTheme;
+  }
+
+  async function updateAppTheme(
+    themeId: string,
+    field: 'default' | 'definition' | 'name',
+    body: Record<string, unknown>,
+    operation: string
+  ): Promise<void> {
+    const res = await auth.authedFetch(`/api/themes/${encodeURIComponent(themeId)}/${field}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await assertOk(res, operation);
+  }
+
+  async function setDefaultAppTheme(themeId: string, isDefault: boolean): Promise<void> {
+    await updateAppTheme(themeId, 'default', { isDefault }, 'setDefaultAppTheme');
+  }
+
+  async function updateAppThemeDefinition(themeId: string, definition: Record<string, unknown>): Promise<void> {
+    await updateAppTheme(themeId, 'definition', { definition }, 'updateAppThemeDefinition');
+  }
+
+  async function renameAppTheme(themeId: string, name: string): Promise<void> {
+    await updateAppTheme(themeId, 'name', { name }, 'renameAppTheme');
+  }
+
+  async function deleteAppTheme(themeId: string): Promise<void> {
+    const res = await auth.authedFetch(`/api/themes/${encodeURIComponent(themeId)}`, { method: 'DELETE' });
+    await assertOk(res, 'deleteAppTheme');
   }
 
   async function updateAppSettings(params: UpdateAppSettingsParams): Promise<void> {
@@ -1738,6 +1796,11 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     getAppSummary,
     getAppSettings,
     listAppThemes,
+    createAppTheme,
+    setDefaultAppTheme,
+    updateAppThemeDefinition,
+    renameAppTheme,
+    deleteAppTheme,
     updateAppSettings,
     getComponent,
     createPage,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -57,6 +57,7 @@ import {
   type RuntimeFreshnessMonitor,
 } from '../runtimeFreshness.js';
 import { getRuntimeInfoTool } from './getRuntimeInfo.js';
+import { manageThemeTool } from './manageTheme.js';
 
 export const LEGACY_SINGULAR_CREATE_TOOL_NAMES = new Set([
   'create_table',
@@ -125,6 +126,7 @@ export function registerTools(
     listEventsTool(client),
     updateEventsTool(client),
     deleteEventTool(client),
+    manageThemeTool(client),
   ];
 
   const exposedTools = includeLegacySingularCreateTools()

--- a/src/tools/manageTheme.ts
+++ b/src/tools/manageTheme.ts
@@ -1,0 +1,138 @@
+import { z } from 'zod';
+import type { AppTheme, ToolJetClient } from '../tooljetClient.js';
+import { fail, ok, type ToolDef } from './types.js';
+
+const colorPair = z.object({
+  light: z.string().trim().min(1).max(100).describe('Color used in light mode; hex is recommended.'),
+  dark: z.string().trim().min(1).max(100).describe('Color used in dark mode; hex is recommended.'),
+}).strict();
+
+const themeDefinition = z.object({
+  brand: z.object({
+    colors: z.object({
+      primary: colorPair,
+      secondary: colorPair.optional(),
+      tertiary: colorPair.optional(),
+    }).strict(),
+  }).strict(),
+  text: z.object({
+    font: z.string().trim().min(1).max(200),
+    colors: z.object({
+      primary: colorPair,
+      placeholder: colorPair.optional(),
+      disabled: colorPair.optional(),
+    }).strict(),
+  }).strict(),
+  border: z.object({
+    radius: z.object({
+      default: z.number().nonnegative(),
+      small: z.number().nonnegative(),
+      large: z.number().nonnegative(),
+    }).strict(),
+    colors: z.object({
+      default: colorPair,
+      weak: colorPair.optional(),
+      disabled: colorPair.optional(),
+    }).strict(),
+  }).strict(),
+  systemStatus: z.object({
+    colors: z.object({
+      success: colorPair,
+      error: colorPair.optional(),
+      warning: colorPair.optional(),
+    }).strict(),
+  }).strict(),
+  surface: z.object({
+    colors: z.object({
+      appBackground: colorPair,
+      surface1: colorPair,
+      surface2: colorPair,
+      surface3: colorPair,
+    }).strict(),
+  }).strict(),
+}).strict();
+
+type Args = {
+  action: 'list' | 'create' | 'set_default' | 'update_definition' | 'rename' | 'delete';
+  theme_id?: string;
+  name?: string;
+  definition?: z.infer<typeof themeDefinition>;
+  is_default?: boolean;
+  confirm?: boolean;
+};
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`manage_theme requires ${label} for this action.`);
+  return value;
+}
+
+async function readTheme(client: ToolJetClient, themeId: string): Promise<AppTheme> {
+  const theme = (await client.listAppThemes()).find((candidate) => candidate.id === themeId);
+  if (!theme) throw new Error(`Theme "${themeId}" is not available in the active workspace.`);
+  return theme;
+}
+
+export function manageThemeTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'manage_theme',
+    description:
+      'Manage workspace theme objects through ToolJet\'s typed theme API. Actions: list, create, set_default, ' +
+      'update_definition, rename, delete. Definitions contain brand, text, border, systemStatus, and surface tokens ' +
+      'with light/dark values. Creating a theme does not apply it to an app; use update_app_settings(theme_id) for that. ' +
+      'Delete requires confirm:true after exact-target approval.',
+    inputSchema: {
+      action: z.enum(['list', 'create', 'set_default', 'update_definition', 'rename', 'delete']),
+      theme_id: z.string().uuid().optional(),
+      name: z.string().trim().min(1).max(100).optional(),
+      definition: themeDefinition.optional(),
+      is_default: z.boolean().optional(),
+      confirm: z.boolean().optional(),
+    },
+    async handler(args: Args) {
+      try {
+        if (args.action === 'list') {
+          return ok({ themes: await client.listAppThemes() });
+        }
+
+        if (args.action === 'create') {
+          const name = requireValue(args.name, 'name');
+          if (name.length < 5) throw new Error('Theme name must contain at least 5 characters.');
+          if (name === 'ToolJet') throw new Error('The reserved theme name "ToolJet" cannot be used.');
+          const created = await client.createAppTheme({
+            name,
+            definition: requireValue(args.definition, 'definition'),
+            isDefault: args.is_default ?? false,
+          });
+          return ok({ theme: created });
+        }
+
+        const themeId = requireValue(args.theme_id, 'theme_id');
+        await readTheme(client, themeId);
+
+        if (args.action === 'set_default') {
+          await client.setDefaultAppTheme(themeId, args.is_default ?? true);
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+
+        if (args.action === 'update_definition') {
+          await client.updateAppThemeDefinition(themeId, requireValue(args.definition, 'definition'));
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+
+        if (args.action === 'rename') {
+          await client.renameAppTheme(themeId, requireValue(args.name, 'name'));
+          return ok({ theme: await readTheme(client, themeId) });
+        }
+
+        if (args.confirm !== true) {
+          throw new Error(`Deleting theme "${themeId}" requires confirm:true after exact-target user approval.`);
+        }
+        await client.deleteAppTheme(themeId);
+        return ok({ deleted: true, theme_id: themeId });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+


### PR DESCRIPTION
Changes:

1. Added the `manage_theme` MCP API for listing, creating, updating, renaming, setting defaults, and deleting workspace themes.
2. Added typed ToolJet client methods and validation for the current theme definition structure.
3. Added guidance for applying themes to apps and using existing theme tokens in component styles.
4. Updated the packaged MCP bundle and skill references so theme management is available in packaged installations.

Impact:

- Speed: No meaningful impact on builds that do not use themes. Theme requests add only the required bounded list/create/update/apply API calls.
- Quality: Improves visual consistency by letting the builder create a validated workspace theme, apply it to the app, and use the same semantic tokens across components.
- Token usage: Adds a small tool-schema and routing overhead. Detailed theme guidance is loaded only when relevant, so ordinary non-theme builds do not receive the full reference content.