### PR TITLE
feat(mcp): expose user and workspace management APIs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,8 @@
         "TOOLJET_URL": "${TOOLJET_URL:-http://localhost:3000}",
         "TOOLJET_APP_URL": "${TOOLJET_APP_URL:-http://localhost:8082}",
         "TOOLJET_EMAIL": "${TOOLJET_EMAIL}",
-        "TOOLJET_PASSWORD": "${TOOLJET_PASSWORD}"
+        "TOOLJET_PASSWORD": "${TOOLJET_PASSWORD}",
+        "TOOLJET_EXTERNAL_API_ACCESS_TOKEN": "${TOOLJET_EXTERNAL_API_ACCESS_TOKEN}"
       }
     }
   }

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@ TOOLJET_URL=http://localhost:3000
 TOOLJET_APP_URL=http://localhost:8082
 TOOLJET_EMAIL=navaneeth@tooljet.com
 TOOLJET_PASSWORD=change-me
+# Optional; required only for instance-wide user/workspace management tools. This must match the
+# ToolJet server's EXTERNAL_API_ACCESS_TOKEN, and ENABLE_EXTERNAL_API must be true on that server.
+# TOOLJET_EXTERNAL_API_ACCESS_TOKEN=change-me
 # Optional compatibility profile for older clients. Batch create tools accept one item and are the default.
 # TOOLJET_INCLUDE_LEGACY_SINGULAR_TOOLS=true
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ TOOLJET_URL=http://localhost:3000        # backend API origin
 TOOLJET_APP_URL=http://localhost:8082    # frontend origin (for app links)
 TOOLJET_EMAIL=you@example.com
 TOOLJET_PASSWORD=your-password
+# Optional; required only for instance-wide user/workspace management tools.
+# Must match EXTERNAL_API_ACCESS_TOKEN on a ToolJet server with ENABLE_EXTERNAL_API=true.
+TOOLJET_EXTERNAL_API_ACCESS_TOKEN=your-external-api-token
 ```
 
 The default MCP profile keeps tool selection compact by exposing batch create tools only; every batch accepts a single item. Older clients can restore the redundant singular aliases with `TOOLJET_INCLUDE_LEGACY_SINGULAR_TOOLS=true`.
@@ -42,6 +45,7 @@ TOOLJET_URL = "http://localhost:3000"
 TOOLJET_APP_URL = "http://localhost:8082"
 TOOLJET_EMAIL = "you@example.com"
 TOOLJET_PASSWORD = "your-password"
+TOOLJET_EXTERNAL_API_ACCESS_TOKEN = "your-external-api-token" # optional; user/workspace management tools only
 ```
 
 Then install the skill so Codex knows how to drive the tools: copy the complete `skill/` directory into your Codex skills directory (or use `npm run sync:skill`). Its compact entry point progressively loads focused references for tables, forms, events, datasources, security, and QA.
@@ -85,6 +89,8 @@ For local development you can also install from a path: `/plugin install path:/U
 ```bash
 export TOOLJET_EMAIL="you@example.com"
 export TOOLJET_PASSWORD="your-password"
+# optional; required only for the instance-wide user/workspace management tools
+export TOOLJET_EXTERNAL_API_ACCESS_TOKEN="your-external-api-token"
 # optional, if not localhost:
 export TOOLJET_URL="https://your-instance.tooljet.com"
 export TOOLJET_APP_URL="https://your-instance.tooljet.com"
@@ -110,6 +116,10 @@ Codex should: `list_datasources` → `create_app` → `lint_app_spec` → `apply
 | Tool | Purpose |
 |---|---|
 | `list_workspaces()` / `use_workspace(workspace_id)` | Inspect or switch the active ToolJet workspace; results include its manual datasource-settings URL |
+| `list_instance_workspaces()` | List every workspace and its assignable custom groups through ToolJet's external API |
+| `list_workspace_apps(workspace_id)` | List the apps and versions in one workspace through ToolJet's external API |
+| `manage_users(...)` | List/get users, create or invite a user, and update profile/status fields; archiving is confirmed |
+| `manage_user_access(...)` | Confirmed workspace-role, membership-status, and existing custom-group assignments; supports full membership replacement when explicitly requested |
 | `create_app(name)` | New app + version + Home page → ids, explicit editor/viewer links, and the workspace datasource-settings URL (`app_url` remains an editor alias) |
 | `list_datasources(version_id)` | Workspace sources available automatically to new/existing apps, each with a direct settings URL; no per-app linking |
 | `get_datasource_query_schema({datasource_id, version_id, operation?, sections?})` | Fetch compact request contracts plus response shape/status when known; also supports kind lookup and batches |

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33169,6 +33169,7 @@ function loadConfig() {
     appUrl: process.env.TOOLJET_APP_URL ?? "http://localhost:8082",
     email: email3,
     password,
+    externalApiAccessToken: process.env.TOOLJET_EXTERNAL_API_ACCESS_TOKEN ?? process.env.TOOLJET_ACCESS_TOKEN ?? process.env.EXTERNAL_API_ACCESS_TOKEN,
     workspaceId: process.env.TOOLJET_WORKSPACE_ID,
     workspaceSlug: process.env.TOOLJET_WORKSPACE_SLUG
   };
@@ -33339,6 +33340,20 @@ function createAuth(config2, fetchImpl = fetch) {
     }
     return res;
   }
+  async function externalApiFetch(path, init) {
+    const accessToken = config2.externalApiAccessToken;
+    if (!accessToken) {
+      throw new Error("ToolJet external API access is not configured. Set TOOLJET_EXTERNAL_API_ACCESS_TOKEN to the same value configured as EXTERNAL_API_ACCESS_TOKEN on the ToolJet instance.");
+    }
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Basic ${accessToken}`);
+    if (!headers.has("Content-Type") && init?.body !== void 0) {
+      headers.set("Content-Type", "application/json");
+    }
+    const response = await fetchImpl(`${config2.apiUrl}${path}`, { ...init, headers });
+    recordHttpResponse(response);
+    return response;
+  }
   async function getOrganizationId() {
     if (!workspaceId)
       await login();
@@ -33363,7 +33378,14 @@ function createAuth(config2, fetchImpl = fetch) {
       await login();
     return switchTo(id);
   }
-  return { authedFetch, getOrganizationId, getOrganizationSlug, listWorkspaces, switchWorkspace };
+  return {
+    authedFetch,
+    externalApiFetch,
+    getOrganizationId,
+    getOrganizationSlug,
+    listWorkspaces,
+    switchWorkspace
+  };
 }
 
 // dist/tooljetClient.js
@@ -34936,6 +34958,101 @@ function tableForeignKeyDto(foreignKey) {
 function createClient(auth, config2) {
   let developmentEnvironmentIdPromise;
   const datasourceManagementUrl = (workspaceSlug, datasourceId) => `${config2.appUrl}/${encodeURIComponent(workspaceSlug)}/data-sources` + (datasourceId ? `/${encodeURIComponent(datasourceId)}` : "");
+  async function externalApiRequest(path, operation, init) {
+    const res = await auth.externalApiFetch(path, init);
+    if (!res.ok) {
+      const detail = await res.text();
+      const hint = res.status === 401 || res.status === 403 ? " Check the external API token and whether this ToolJet plan allows the requested operation." : res.status === 404 ? " Check that ENABLE_EXTERNAL_API=true on the ToolJet instance." : "";
+      throw new Error(`ToolJet ${operation} failed (${res.status}): ${detail}${hint}`);
+    }
+    return res;
+  }
+  async function listInstanceWorkspaces() {
+    const res = await externalApiRequest("/api/ext/workspaces", "listInstanceWorkspaces");
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error("ToolJet listInstanceWorkspaces failed: expected an array response.");
+    }
+    return body;
+  }
+  async function listWorkspaceApps(workspaceId) {
+    const res = await externalApiRequest(`/api/ext/workspace/${encodeURIComponent(workspaceId)}/apps`, "listWorkspaceApps");
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error("ToolJet listWorkspaceApps failed: expected an array response.");
+    }
+    return body;
+  }
+  async function listInstanceUsers(params = {}) {
+    const query = new URLSearchParams();
+    if (params.groupNames?.length)
+      query.set("group_names", params.groupNames.join(","));
+    if (params.statuses?.length)
+      query.set("status", params.statuses.join(","));
+    const suffix = query.size ? `?${query.toString()}` : "";
+    const res = await externalApiRequest(`/api/ext/users${suffix}`, "listInstanceUsers");
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error("ToolJet listInstanceUsers failed: expected an array response.");
+    }
+    return body;
+  }
+  async function getInstanceUser(userIdOrEmail) {
+    const res = await externalApiRequest(`/api/ext/user/${encodeURIComponent(userIdOrEmail)}`, "getInstanceUser");
+    const body = await res.json();
+    if (!body || Array.isArray(body) || typeof body !== "object" || typeof body.id !== "string") {
+      throw new Error(`ToolJet getInstanceUser failed: user "${userIdOrEmail}" was not found.`);
+    }
+    return body;
+  }
+  async function createInstanceUser(params) {
+    const res = await externalApiRequest("/api/ext/users", "createInstanceUser", {
+      method: "POST",
+      body: JSON.stringify({
+        name: params.name,
+        email: params.email,
+        ...params.password !== void 0 ? { password: params.password } : {},
+        status: params.status ?? "invited",
+        ...params.defaultWorkspaceId ? { defaultOrganizationId: params.defaultWorkspaceId } : {},
+        workspaces: params.workspaces
+      })
+    });
+    const body = await res.json();
+    if (body && !Array.isArray(body) && typeof body === "object" && typeof body.id === "string") {
+      return body;
+    }
+    return getInstanceUser(params.email);
+  }
+  async function updateInstanceUser(userId, params) {
+    await externalApiRequest(`/api/ext/user/${encodeURIComponent(userId)}`, "updateInstanceUser", {
+      method: "PATCH",
+      body: JSON.stringify({
+        ...params.name !== void 0 ? { name: params.name } : {},
+        ...params.email !== void 0 ? { email: params.email } : {},
+        ...params.password !== void 0 ? { password: params.password } : {},
+        ...params.status !== void 0 ? { status: params.status } : {},
+        ...params.defaultWorkspaceId !== void 0 ? { defaultOrganizationId: params.defaultWorkspaceId } : {}
+      })
+    });
+  }
+  async function updateInstanceUserRole(params) {
+    await externalApiRequest(`/api/ext/update-user-role/workspace/${encodeURIComponent(params.workspaceId)}`, "updateInstanceUserRole", {
+      method: "PUT",
+      body: JSON.stringify({ userId: params.userId, newRole: params.role })
+    });
+  }
+  async function updateInstanceUserWorkspace(params) {
+    await externalApiRequest(`/api/ext/user/${encodeURIComponent(params.userId)}/workspace/${encodeURIComponent(params.workspaceId)}`, "updateInstanceUserWorkspace", {
+      method: "PATCH",
+      body: JSON.stringify({
+        ...params.status !== void 0 ? { status: params.status } : {},
+        ...params.groups !== void 0 ? { groups: params.groups } : {}
+      })
+    });
+  }
+  async function replaceInstanceUserWorkspaces(userId, workspaces) {
+    await externalApiRequest(`/api/ext/user/${encodeURIComponent(userId)}/workspaces`, "replaceInstanceUserWorkspaces", { method: "PUT", body: JSON.stringify(workspaces) });
+  }
   async function getApp(appId) {
     const res = await auth.authedFetch(`/api/apps/${appId}`);
     await assertOk(res, "getApp");
@@ -35869,6 +35986,15 @@ function createClient(auth, config2) {
   return {
     listWorkspaces,
     useWorkspace,
+    listInstanceWorkspaces,
+    listWorkspaceApps,
+    listInstanceUsers,
+    getInstanceUser,
+    createInstanceUser,
+    updateInstanceUser,
+    updateInstanceUserRole,
+    updateInstanceUserWorkspace,
+    replaceInstanceUserWorkspaces,
     createApp,
     renameApp,
     getApp,
@@ -41653,6 +41779,177 @@ function manageThemeTool(client) {
   };
 }
 
+// dist/tools/userManagement.js
+var userStatus = external_exports.enum(["active", "archived", "invited"]);
+var userRole = external_exports.enum(["admin", "builder", "end-user"]);
+var groupRef = external_exports.object({
+  id: external_exports.string().uuid().optional(),
+  name: external_exports.string().trim().min(1).max(100).optional()
+}).strict().refine((group) => group.id !== void 0 || group.name !== void 0, {
+  message: "Each group requires either id or name."
+});
+var workspaceRef = external_exports.object({
+  id: external_exports.string().uuid().optional(),
+  name: external_exports.string().trim().min(1).max(100).optional(),
+  role: userRole.optional(),
+  status: userStatus.optional(),
+  groups: external_exports.array(groupRef).max(100).optional()
+}).strict().refine((workspace) => workspace.id !== void 0 || workspace.name !== void 0, {
+  message: "Each workspace requires either id or name."
+});
+function requireValue2(value, label) {
+  if (value === void 0)
+    throw new Error(`${label} is required for this action.`);
+  return value;
+}
+function requireUuid(value, label) {
+  const parsed = external_exports.string().uuid().safeParse(value);
+  if (!parsed.success)
+    throw new Error(`${label} must be a UUID for this action.`);
+  return parsed.data;
+}
+function listInstanceWorkspacesTool(client) {
+  return {
+    name: "list_instance_workspaces",
+    description: "List every workspace visible to ToolJet's instance-wide external API, including the existing custom groups that can be assigned to users. This is different from list_workspaces, which lists only the signed-in app-builder user's workspaces. Requires TOOLJET_EXTERNAL_API_ACCESS_TOKEN.",
+    inputSchema: {},
+    async handler() {
+      try {
+        return ok({ workspaces: await client.listInstanceWorkspaces() });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+function listWorkspaceAppsTool(client) {
+  return {
+    name: "list_workspace_apps",
+    description: "List app ids, names, slugs, and versions for one workspace through ToolJet's external API. Use list_instance_workspaces first instead of guessing a workspace id.",
+    inputSchema: {
+      workspace_id: external_exports.string().uuid()
+    },
+    async handler(args) {
+      try {
+        return ok({ apps: await client.listWorkspaceApps(args.workspace_id) });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+function manageUsersTool(client) {
+  return {
+    name: "manage_users",
+    description: "List, get, create/invite, or update ToolJet instance users through the public external API. Create defaults to invited and never invents a password. Update changes only supplied fields; archiving requires confirm:true after exact-target approval. Passwords are write-only and are never returned.",
+    inputSchema: {
+      action: external_exports.enum(["list", "get", "create", "update"]),
+      user_id: external_exports.string().trim().min(1).optional().describe("User UUID; get also accepts an exact email."),
+      group_names: external_exports.array(external_exports.string().trim().min(1).max(100)).max(50).optional(),
+      statuses: external_exports.array(userStatus).max(3).optional(),
+      name: external_exports.string().trim().min(1).max(100).optional(),
+      email: external_exports.string().email().optional(),
+      password: external_exports.string().min(5).max(100).optional().describe("Write-only; provide only when explicitly requested."),
+      status: userStatus.optional(),
+      default_workspace_id: external_exports.string().uuid().optional(),
+      workspaces: external_exports.array(workspaceRef).min(1).max(100).optional(),
+      confirm: external_exports.boolean().optional()
+    },
+    async handler(args) {
+      try {
+        if (args.action === "list") {
+          return ok({
+            users: await client.listInstanceUsers({
+              groupNames: args.group_names,
+              statuses: args.statuses
+            })
+          });
+        }
+        if (args.action === "get") {
+          return ok({ user: await client.getInstanceUser(requireValue2(args.user_id, "user_id")) });
+        }
+        if (args.action === "create") {
+          const created = await client.createInstanceUser({
+            name: requireValue2(args.name, "name"),
+            email: requireValue2(args.email, "email"),
+            ...args.password !== void 0 ? { password: args.password } : {},
+            status: args.status ?? "invited",
+            ...args.default_workspace_id ? { defaultWorkspaceId: args.default_workspace_id } : {},
+            workspaces: requireValue2(args.workspaces, "workspaces")
+          });
+          return ok({ user: created });
+        }
+        const userId = requireUuid(requireValue2(args.user_id, "user_id"), "user_id");
+        const current = await client.getInstanceUser(userId);
+        const update = {
+          ...args.name !== void 0 ? { name: args.name } : {},
+          ...args.email !== void 0 ? { email: args.email } : {},
+          ...args.password !== void 0 ? { password: args.password } : {},
+          ...args.status !== void 0 ? { status: args.status } : {},
+          ...args.default_workspace_id !== void 0 ? { defaultWorkspaceId: args.default_workspace_id } : {}
+        };
+        if (!Object.keys(update).length) {
+          throw new Error("manage_users update requires at least one changed field.");
+        }
+        if (args.status === "archived" && args.confirm !== true) {
+          throw new Error(`Archiving user "${current.email ?? current.name ?? userId}" requires confirm:true after exact-target approval.`);
+        }
+        await client.updateInstanceUser(userId, update);
+        return ok({ user: await client.getInstanceUser(userId) });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+function manageUserAccessTool(client) {
+  return {
+    name: "manage_user_access",
+    description: "Change one ToolJet user's workspace role, status, or existing custom-group membership, or replace the user's complete workspace set. All actions require confirm:true after exact user/workspace approval. update_workspace replaces that workspace's complete custom-group list when groups is supplied; replace_workspaces removes every omitted membership. This tool does not create groups or permission policies.",
+    inputSchema: {
+      action: external_exports.enum(["set_role", "update_workspace", "replace_workspaces"]),
+      user_id: external_exports.string().uuid(),
+      workspace_id: external_exports.string().uuid().optional(),
+      role: userRole.optional(),
+      status: userStatus.optional(),
+      groups: external_exports.array(groupRef).max(100).optional(),
+      workspaces: external_exports.array(workspaceRef).max(100).optional(),
+      confirm: external_exports.boolean().optional()
+    },
+    async handler(args) {
+      try {
+        const userId = requireValue2(args.user_id, "user_id");
+        const current = await client.getInstanceUser(userId);
+        if (args.confirm !== true) {
+          throw new Error(`Changing access for user "${current.email ?? current.name ?? userId}" requires confirm:true after exact-target approval.`);
+        }
+        if (args.action === "set_role") {
+          await client.updateInstanceUserRole({
+            userId,
+            workspaceId: requireValue2(args.workspace_id, "workspace_id"),
+            role: requireValue2(args.role, "role")
+          });
+        } else if (args.action === "update_workspace") {
+          if (args.status === void 0 && args.groups === void 0) {
+            throw new Error("update_workspace requires status and/or groups.");
+          }
+          await client.updateInstanceUserWorkspace({
+            userId,
+            workspaceId: requireValue2(args.workspace_id, "workspace_id"),
+            ...args.status !== void 0 ? { status: args.status } : {},
+            ...args.groups !== void 0 ? { groups: args.groups } : {}
+          });
+        } else {
+          await client.replaceInstanceUserWorkspaces(userId, requireValue2(args.workspaces, "workspaces"));
+        }
+        return ok({ user: await client.getInstanceUser(userId) });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+
 // dist/tools/index.js
 var LEGACY_SINGULAR_CREATE_TOOL_NAMES = /* @__PURE__ */ new Set([
   "create_table",
@@ -41669,6 +41966,10 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     getRuntimeInfoTool(runtime),
     listWorkspacesTool(client),
     useWorkspaceTool(client),
+    listInstanceWorkspacesTool(client),
+    listWorkspaceAppsTool(client),
+    manageUsersTool(client),
+    manageUserAccessTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,8 @@ export interface Workspace {
 
 export interface Auth {
   authedFetch(path: string, init?: RequestInit): Promise<Response>;
+  /** Call ToolJet's instance-wide /api/ext surface with its separately configured Basic token. */
+  externalApiFetch(path: string, init?: RequestInit): Promise<Response>;
   getOrganizationId(): Promise<string>;
   getOrganizationSlug(): Promise<string>;
   /** The workspaces this user belongs to (id, name, slug, is_default, is_current). */
@@ -175,6 +177,25 @@ export function createAuth(config: Config, fetchImpl: typeof fetch = fetch): Aut
     return res;
   }
 
+  async function externalApiFetch(path: string, init?: RequestInit): Promise<Response> {
+    const accessToken = config.externalApiAccessToken;
+    if (!accessToken) {
+      throw new Error(
+        'ToolJet external API access is not configured. Set TOOLJET_EXTERNAL_API_ACCESS_TOKEN to the ' +
+          'same value configured as EXTERNAL_API_ACCESS_TOKEN on the ToolJet instance.'
+      );
+    }
+
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Basic ${accessToken}`);
+    if (!headers.has('Content-Type') && init?.body !== undefined) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const response = await fetchImpl(`${config.apiUrl}${path}`, { ...init, headers });
+    recordHttpResponse(response);
+    return response;
+  }
+
   async function getOrganizationId(): Promise<string> {
     if (!workspaceId) await login();
     if (!workspaceId) throw new Error('ToolJet getOrganizationId failed: no organization id available after login');
@@ -197,5 +218,12 @@ export function createAuth(config: Config, fetchImpl: typeof fetch = fetch): Aut
     return switchTo(id);
   }
 
-  return { authedFetch, getOrganizationId, getOrganizationSlug, listWorkspaces, switchWorkspace };
+  return {
+    authedFetch,
+    externalApiFetch,
+    getOrganizationId,
+    getOrganizationSlug,
+    listWorkspaces,
+    switchWorkspace,
+  };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ export interface Config {
   appUrl: string;
   email: string;
   password: string;
+  /** Instance-wide ToolJet external API token used only by user/workspace management tools. */
+  externalApiAccessToken?: string;
   /** Optional: pin the active workspace at startup (for multi-workspace users). id wins over slug. */
   workspaceId?: string;
   workspaceSlug?: string;
@@ -18,6 +20,10 @@ export function loadConfig(): Config {
     appUrl: process.env.TOOLJET_APP_URL ?? 'http://localhost:8082',
     email,
     password,
+    externalApiAccessToken:
+      process.env.TOOLJET_EXTERNAL_API_ACCESS_TOKEN ??
+      process.env.TOOLJET_ACCESS_TOKEN ??
+      process.env.EXTERNAL_API_ACCESS_TOKEN,
     workspaceId: process.env.TOOLJET_WORKSPACE_ID,
     workspaceSlug: process.env.TOOLJET_WORKSPACE_SLUG,
   };

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -39,6 +39,66 @@ export interface CreateAppThemeParams {
   isDefault?: boolean;
 }
 
+export type InstanceUserStatus = 'active' | 'archived' | 'invited';
+export type WorkspaceUserRole = 'admin' | 'builder' | 'end-user';
+
+export interface UserGroupRef {
+  id?: string;
+  name?: string;
+}
+
+export interface UserWorkspaceRef {
+  id?: string;
+  name?: string;
+  role?: WorkspaceUserRole;
+  status?: InstanceUserStatus;
+  groups?: UserGroupRef[];
+}
+
+export interface InstanceUser {
+  id: string;
+  name?: string;
+  email?: string;
+  status?: InstanceUserStatus;
+  workspaces?: Array<Record<string, unknown>>;
+  userGroups?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export interface InstanceWorkspace {
+  id: string;
+  name: string;
+  status?: string;
+  groups: Array<{ id: string; name: string; type?: string }>;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceApp {
+  id: string;
+  name?: string;
+  slug?: string;
+  organizationId?: string;
+  versions?: Array<{ id: string; name?: string }>;
+  [key: string]: unknown;
+}
+
+export interface CreateInstanceUserParams {
+  name: string;
+  email: string;
+  password?: string;
+  status?: InstanceUserStatus;
+  defaultWorkspaceId?: string;
+  workspaces: UserWorkspaceRef[];
+}
+
+export interface UpdateInstanceUserParams {
+  name?: string;
+  email?: string;
+  password?: string;
+  status?: InstanceUserStatus;
+  defaultWorkspaceId?: string;
+}
+
 export interface AppSettingsSnapshot {
   app_id: string;
   version_id: string;
@@ -384,6 +444,24 @@ export interface QuerySummary {
 export interface ToolJetClient {
   listWorkspaces(): Promise<Workspace[]>;
   useWorkspace(workspaceId: string): Promise<Workspace>;
+  listInstanceWorkspaces(): Promise<InstanceWorkspace[]>;
+  listWorkspaceApps(workspaceId: string): Promise<WorkspaceApp[]>;
+  listInstanceUsers(params?: { groupNames?: string[]; statuses?: InstanceUserStatus[] }): Promise<InstanceUser[]>;
+  getInstanceUser(userIdOrEmail: string): Promise<InstanceUser>;
+  createInstanceUser(params: CreateInstanceUserParams): Promise<InstanceUser>;
+  updateInstanceUser(userId: string, params: UpdateInstanceUserParams): Promise<void>;
+  updateInstanceUserRole(params: {
+    workspaceId: string;
+    userId: string;
+    role: WorkspaceUserRole;
+  }): Promise<void>;
+  updateInstanceUserWorkspace(params: {
+    userId: string;
+    workspaceId: string;
+    status?: InstanceUserStatus;
+    groups?: UserGroupRef[];
+  }): Promise<void>;
+  replaceInstanceUserWorkspaces(userId: string, workspaces: UserWorkspaceRef[]): Promise<void>;
   createApp(name: string): Promise<CreateAppResult>;
   renameApp(appId: string, versionId: string, name: string): Promise<void>;
   getApp(appId: string): Promise<any>;
@@ -561,6 +639,152 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   const datasourceManagementUrl = (workspaceSlug: string, datasourceId?: string) =>
     `${config.appUrl}/${encodeURIComponent(workspaceSlug)}/data-sources` +
     (datasourceId ? `/${encodeURIComponent(datasourceId)}` : '');
+
+  async function externalApiRequest(
+    path: string,
+    operation: string,
+    init?: RequestInit
+  ): Promise<Response> {
+    const res = await auth.externalApiFetch(path, init);
+    if (!res.ok) {
+      const detail = await res.text();
+      const hint =
+        res.status === 401 || res.status === 403
+          ? ' Check the external API token and whether this ToolJet plan allows the requested operation.'
+          : res.status === 404
+            ? ' Check that ENABLE_EXTERNAL_API=true on the ToolJet instance.'
+            : '';
+      throw new Error(`ToolJet ${operation} failed (${res.status}): ${detail}${hint}`);
+    }
+    return res;
+  }
+
+  async function listInstanceWorkspaces(): Promise<InstanceWorkspace[]> {
+    const res = await externalApiRequest('/api/ext/workspaces', 'listInstanceWorkspaces');
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error('ToolJet listInstanceWorkspaces failed: expected an array response.');
+    }
+    return body as InstanceWorkspace[];
+  }
+
+  async function listWorkspaceApps(workspaceId: string): Promise<WorkspaceApp[]> {
+    const res = await externalApiRequest(
+      `/api/ext/workspace/${encodeURIComponent(workspaceId)}/apps`,
+      'listWorkspaceApps'
+    );
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error('ToolJet listWorkspaceApps failed: expected an array response.');
+    }
+    return body as WorkspaceApp[];
+  }
+
+  async function listInstanceUsers(
+    params: { groupNames?: string[]; statuses?: InstanceUserStatus[] } = {}
+  ): Promise<InstanceUser[]> {
+    const query = new URLSearchParams();
+    if (params.groupNames?.length) query.set('group_names', params.groupNames.join(','));
+    if (params.statuses?.length) query.set('status', params.statuses.join(','));
+    const suffix = query.size ? `?${query.toString()}` : '';
+    const res = await externalApiRequest(`/api/ext/users${suffix}`, 'listInstanceUsers');
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error('ToolJet listInstanceUsers failed: expected an array response.');
+    }
+    return body as InstanceUser[];
+  }
+
+  async function getInstanceUser(userIdOrEmail: string): Promise<InstanceUser> {
+    const res = await externalApiRequest(
+      `/api/ext/user/${encodeURIComponent(userIdOrEmail)}`,
+      'getInstanceUser'
+    );
+    const body = await res.json();
+    if (!body || Array.isArray(body) || typeof body !== 'object' || typeof body.id !== 'string') {
+      throw new Error(`ToolJet getInstanceUser failed: user "${userIdOrEmail}" was not found.`);
+    }
+    return body as InstanceUser;
+  }
+
+  async function createInstanceUser(params: CreateInstanceUserParams): Promise<InstanceUser> {
+    const res = await externalApiRequest('/api/ext/users', 'createInstanceUser', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: params.name,
+        email: params.email,
+        ...(params.password !== undefined ? { password: params.password } : {}),
+        status: params.status ?? 'invited',
+        ...(params.defaultWorkspaceId ? { defaultOrganizationId: params.defaultWorkspaceId } : {}),
+        workspaces: params.workspaces,
+      }),
+    });
+    const body = await res.json();
+    if (body && !Array.isArray(body) && typeof body === 'object' && typeof body.id === 'string') {
+      return body as InstanceUser;
+    }
+    return getInstanceUser(params.email);
+  }
+
+  async function updateInstanceUser(userId: string, params: UpdateInstanceUserParams): Promise<void> {
+    await externalApiRequest(`/api/ext/user/${encodeURIComponent(userId)}`, 'updateInstanceUser', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...(params.name !== undefined ? { name: params.name } : {}),
+        ...(params.email !== undefined ? { email: params.email } : {}),
+        ...(params.password !== undefined ? { password: params.password } : {}),
+        ...(params.status !== undefined ? { status: params.status } : {}),
+        ...(params.defaultWorkspaceId !== undefined
+          ? { defaultOrganizationId: params.defaultWorkspaceId }
+          : {}),
+      }),
+    });
+  }
+
+  async function updateInstanceUserRole(params: {
+    workspaceId: string;
+    userId: string;
+    role: WorkspaceUserRole;
+  }): Promise<void> {
+    await externalApiRequest(
+      `/api/ext/update-user-role/workspace/${encodeURIComponent(params.workspaceId)}`,
+      'updateInstanceUserRole',
+      {
+        method: 'PUT',
+        body: JSON.stringify({ userId: params.userId, newRole: params.role }),
+      }
+    );
+  }
+
+  async function updateInstanceUserWorkspace(params: {
+    userId: string;
+    workspaceId: string;
+    status?: InstanceUserStatus;
+    groups?: UserGroupRef[];
+  }): Promise<void> {
+    await externalApiRequest(
+      `/api/ext/user/${encodeURIComponent(params.userId)}/workspace/${encodeURIComponent(params.workspaceId)}`,
+      'updateInstanceUserWorkspace',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          ...(params.status !== undefined ? { status: params.status } : {}),
+          ...(params.groups !== undefined ? { groups: params.groups } : {}),
+        }),
+      }
+    );
+  }
+
+  async function replaceInstanceUserWorkspaces(
+    userId: string,
+    workspaces: UserWorkspaceRef[]
+  ): Promise<void> {
+    await externalApiRequest(
+      `/api/ext/user/${encodeURIComponent(userId)}/workspaces`,
+      'replaceInstanceUserWorkspaces',
+      { method: 'PUT', body: JSON.stringify(workspaces) }
+    );
+  }
 
   async function getApp(appId: string): Promise<any> {
     const res = await auth.authedFetch(`/api/apps/${appId}`);
@@ -1790,6 +2014,15 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   return {
     listWorkspaces,
     useWorkspace,
+    listInstanceWorkspaces,
+    listWorkspaceApps,
+    listInstanceUsers,
+    getInstanceUser,
+    createInstanceUser,
+    updateInstanceUser,
+    updateInstanceUserRole,
+    updateInstanceUserWorkspace,
+    replaceInstanceUserWorkspaces,
     createApp,
     renameApp,
     getApp,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -58,6 +58,12 @@ import {
 } from '../runtimeFreshness.js';
 import { getRuntimeInfoTool } from './getRuntimeInfo.js';
 import { manageThemeTool } from './manageTheme.js';
+import {
+  listInstanceWorkspacesTool,
+  listWorkspaceAppsTool,
+  manageUserAccessTool,
+  manageUsersTool,
+} from './userManagement.js';
 
 export const LEGACY_SINGULAR_CREATE_TOOL_NAMES = new Set([
   'create_table',
@@ -80,6 +86,10 @@ export function registerTools(
     getRuntimeInfoTool(runtime),
     listWorkspacesTool(client),
     useWorkspaceTool(client),
+    listInstanceWorkspacesTool(client),
+    listWorkspaceAppsTool(client),
+    manageUsersTool(client),
+    manageUserAccessTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/src/tools/userManagement.ts
+++ b/src/tools/userManagement.ts
@@ -1,0 +1,242 @@
+import { z } from 'zod';
+import type {
+  UserGroupRef,
+  UserWorkspaceRef,
+  InstanceUserStatus,
+  ToolJetClient,
+  WorkspaceUserRole,
+} from '../tooljetClient.js';
+import { fail, ok, type ToolDef } from './types.js';
+
+const userStatus = z.enum(['active', 'archived', 'invited']);
+const userRole = z.enum(['admin', 'builder', 'end-user']);
+
+const groupRef = z
+  .object({
+    id: z.string().uuid().optional(),
+    name: z.string().trim().min(1).max(100).optional(),
+  })
+  .strict()
+  .refine((group) => group.id !== undefined || group.name !== undefined, {
+    message: 'Each group requires either id or name.',
+  });
+
+const workspaceRef = z
+  .object({
+    id: z.string().uuid().optional(),
+    name: z.string().trim().min(1).max(100).optional(),
+    role: userRole.optional(),
+    status: userStatus.optional(),
+    groups: z.array(groupRef).max(100).optional(),
+  })
+  .strict()
+  .refine((workspace) => workspace.id !== undefined || workspace.name !== undefined, {
+    message: 'Each workspace requires either id or name.',
+  });
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`${label} is required for this action.`);
+  return value;
+}
+
+function requireUuid(value: string, label: string): string {
+  const parsed = z.string().uuid().safeParse(value);
+  if (!parsed.success) throw new Error(`${label} must be a UUID for this action.`);
+  return parsed.data;
+}
+
+export function listInstanceWorkspacesTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'list_instance_workspaces',
+    description:
+      'List every workspace visible to ToolJet\'s instance-wide external API, including the existing custom ' +
+      'groups that can be assigned to users. This is different from list_workspaces, which lists only the ' +
+      'signed-in app-builder user\'s workspaces. Requires TOOLJET_EXTERNAL_API_ACCESS_TOKEN.',
+    inputSchema: {},
+    async handler() {
+      try {
+        return ok({ workspaces: await client.listInstanceWorkspaces() });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+
+export function listWorkspaceAppsTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'list_workspace_apps',
+    description:
+      'List app ids, names, slugs, and versions for one workspace through ToolJet\'s external API. ' +
+      'Use list_instance_workspaces first instead of guessing a workspace id.',
+    inputSchema: {
+      workspace_id: z.string().uuid(),
+    },
+    async handler(args: { workspace_id: string }) {
+      try {
+        return ok({ apps: await client.listWorkspaceApps(args.workspace_id) });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+
+type ManageUsersArgs = {
+  action: 'list' | 'get' | 'create' | 'update';
+  user_id?: string;
+  group_names?: string[];
+  statuses?: InstanceUserStatus[];
+  name?: string;
+  email?: string;
+  password?: string;
+  status?: InstanceUserStatus;
+  default_workspace_id?: string;
+  workspaces?: UserWorkspaceRef[];
+  confirm?: boolean;
+};
+
+export function manageUsersTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'manage_users',
+    description:
+      'List, get, create/invite, or update ToolJet instance users through the public external API. ' +
+      'Create defaults to invited and never invents a password. Update changes only supplied fields; archiving ' +
+      'requires confirm:true after exact-target approval. Passwords are write-only and are never returned.',
+    inputSchema: {
+      action: z.enum(['list', 'get', 'create', 'update']),
+      user_id: z.string().trim().min(1).optional().describe('User UUID; get also accepts an exact email.'),
+      group_names: z.array(z.string().trim().min(1).max(100)).max(50).optional(),
+      statuses: z.array(userStatus).max(3).optional(),
+      name: z.string().trim().min(1).max(100).optional(),
+      email: z.string().email().optional(),
+      password: z.string().min(5).max(100).optional().describe('Write-only; provide only when explicitly requested.'),
+      status: userStatus.optional(),
+      default_workspace_id: z.string().uuid().optional(),
+      workspaces: z.array(workspaceRef).min(1).max(100).optional(),
+      confirm: z.boolean().optional(),
+    },
+    async handler(args: ManageUsersArgs) {
+      try {
+        if (args.action === 'list') {
+          return ok({
+            users: await client.listInstanceUsers({
+              groupNames: args.group_names,
+              statuses: args.statuses,
+            }),
+          });
+        }
+
+        if (args.action === 'get') {
+          return ok({ user: await client.getInstanceUser(requireValue(args.user_id, 'user_id')) });
+        }
+
+        if (args.action === 'create') {
+          const created = await client.createInstanceUser({
+            name: requireValue(args.name, 'name'),
+            email: requireValue(args.email, 'email'),
+            ...(args.password !== undefined ? { password: args.password } : {}),
+            status: args.status ?? 'invited',
+            ...(args.default_workspace_id ? { defaultWorkspaceId: args.default_workspace_id } : {}),
+            workspaces: requireValue(args.workspaces, 'workspaces'),
+          });
+          return ok({ user: created });
+        }
+
+        const userId = requireUuid(requireValue(args.user_id, 'user_id'), 'user_id');
+        const current = await client.getInstanceUser(userId);
+        const update = {
+          ...(args.name !== undefined ? { name: args.name } : {}),
+          ...(args.email !== undefined ? { email: args.email } : {}),
+          ...(args.password !== undefined ? { password: args.password } : {}),
+          ...(args.status !== undefined ? { status: args.status } : {}),
+          ...(args.default_workspace_id !== undefined
+            ? { defaultWorkspaceId: args.default_workspace_id }
+            : {}),
+        };
+        if (!Object.keys(update).length) {
+          throw new Error('manage_users update requires at least one changed field.');
+        }
+        if (args.status === 'archived' && args.confirm !== true) {
+          throw new Error(
+            `Archiving user "${current.email ?? current.name ?? userId}" requires confirm:true after exact-target approval.`
+          );
+        }
+        await client.updateInstanceUser(userId, update);
+        return ok({ user: await client.getInstanceUser(userId) });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+
+type ManageUserAccessArgs = {
+  action: 'set_role' | 'update_workspace' | 'replace_workspaces';
+  user_id?: string;
+  workspace_id?: string;
+  role?: WorkspaceUserRole;
+  status?: InstanceUserStatus;
+  groups?: UserGroupRef[];
+  workspaces?: UserWorkspaceRef[];
+  confirm?: boolean;
+};
+
+export function manageUserAccessTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'manage_user_access',
+    description:
+      'Change one ToolJet user\'s workspace role, status, or existing custom-group membership, or replace the ' +
+      'user\'s complete workspace set. All actions require confirm:true after exact user/workspace approval. ' +
+      'update_workspace replaces that workspace\'s complete custom-group list when groups is supplied; ' +
+      'replace_workspaces removes every omitted membership. This tool does not create groups or permission policies.',
+    inputSchema: {
+      action: z.enum(['set_role', 'update_workspace', 'replace_workspaces']),
+      user_id: z.string().uuid(),
+      workspace_id: z.string().uuid().optional(),
+      role: userRole.optional(),
+      status: userStatus.optional(),
+      groups: z.array(groupRef).max(100).optional(),
+      workspaces: z.array(workspaceRef).max(100).optional(),
+      confirm: z.boolean().optional(),
+    },
+    async handler(args: ManageUserAccessArgs) {
+      try {
+        const userId = requireValue(args.user_id, 'user_id');
+        const current = await client.getInstanceUser(userId);
+        if (args.confirm !== true) {
+          throw new Error(
+            `Changing access for user "${current.email ?? current.name ?? userId}" requires confirm:true after exact-target approval.`
+          );
+        }
+
+        if (args.action === 'set_role') {
+          await client.updateInstanceUserRole({
+            userId,
+            workspaceId: requireValue(args.workspace_id, 'workspace_id'),
+            role: requireValue(args.role, 'role'),
+          });
+        } else if (args.action === 'update_workspace') {
+          if (args.status === undefined && args.groups === undefined) {
+            throw new Error('update_workspace requires status and/or groups.');
+          }
+          await client.updateInstanceUserWorkspace({
+            userId,
+            workspaceId: requireValue(args.workspace_id, 'workspace_id'),
+            ...(args.status !== undefined ? { status: args.status } : {}),
+            ...(args.groups !== undefined ? { groups: args.groups } : {}),
+          });
+        } else {
+          await client.replaceInstanceUserWorkspaces(
+            userId,
+            requireValue(args.workspaces, 'workspaces')
+          );
+        }
+
+        return ok({ user: await client.getInstanceUser(userId) });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Changes

1. Added APIs to list workspaces and applications available to the authenticated ToolJet instance.
2. Added user management for listing, viewing, creating, inviting, updating, activating, archiving, and unarchiving users.
3. Added workspace membership and role management, including custom-group membership operations.
4. Added confirmation guards for state-changing actions and separated ToolJet session authentication from external API token authentication.
5. Added concise MCP guidance for required external API configuration.

## Impact

- **Speed:** Reduces manual workspace-administration steps by exposing related operations through compact action-based tools.
- **Quality:** Uses explicit identifiers, validation, and confirmation guards for sensitive mutations.
- **Token usage:** Keeps discovery and mutations grouped into focused tools with compact responses instead of exposing many independent tools.

## Configuration

The ToolJet server must enable its external API and configure an access token. MCP must use the matching token through `TOOLJET_EXTERNAL_API_ACCESS_TOKEN`.
