### PR TITLE
feat: add test_datasource_connection tool

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33516,6 +33516,7 @@ var PROPERTY_KEY_ALIASES = {
   weight: "fontWeight",
   align: "textAlign"
 };
+var VALID_HEADER_CASING = /* @__PURE__ */ new Set(["none", "uppercase"]);
 var DEPRECATED_TABLE_COLUMN_TYPES = {
   default: "string",
   badge: "newMultiSelect",
@@ -33526,7 +33527,6 @@ var DEPRECATED_TABLE_COLUMN_TYPES = {
   toggle: "select",
   multiselect: "newMultiSelect"
 };
-var VALID_HEADER_CASING = /* @__PURE__ */ new Set(["none", "uppercase"]);
 var FORM_INPUT_TYPES = /* @__PURE__ */ new Set([
   "TextInput",
   "NumberInput",
@@ -35898,6 +35898,35 @@ function createClient(auth, config2) {
     await assertOk(res, "invokeDatasourceMethod");
     return await res.json();
   }
+  async function getDatasourceConnectionDetails(dataSourceId, environmentId) {
+    const envId = environmentId ?? await getDevelopmentEnvironmentId();
+    const res = await auth.authedFetch(`/api/data-sources/${encodeURIComponent(dataSourceId)}/environment/${encodeURIComponent(envId)}`);
+    await assertOk(res, "getDatasourceConnectionDetails");
+    const body = await res.json();
+    const pluginId = body.pluginId ?? body.plugin_id ?? void 0;
+    return {
+      kind: body.kind,
+      ...pluginId ? { pluginId } : {},
+      options: body.options ?? {}
+    };
+  }
+  async function testDatasourceConnection(params) {
+    const environmentId = params.environmentId ?? await getDevelopmentEnvironmentId();
+    const res = await auth.authedFetch(`/api/data-sources/${encodeURIComponent(params.dataSourceId)}/test-connection`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: params.kind,
+        options: params.options,
+        environment_id: environmentId,
+        // ToolJet validates plugin_id as a UUID; core datasources have none, so it must be
+        // omitted rather than sent as null.
+        ...params.pluginId ? { plugin_id: params.pluginId } : {}
+      })
+    });
+    await assertOk(res, "testDatasourceConnection");
+    return await res.json();
+  }
   async function listEvents(params) {
     const qs = params.sourceId ? `?sourceId=${encodeURIComponent(params.sourceId)}` : "";
     const res = await auth.authedFetch(`/api/v2/apps/${params.appId}/versions/${params.versionId}/events${qs}`);
@@ -35981,6 +36010,8 @@ function createClient(auth, config2) {
     getQuery,
     runQuery,
     invokeDatasourceMethod,
+    getDatasourceConnectionDetails,
+    testDatasourceConnection,
     listEvents,
     updateEvents,
     deleteEvent
@@ -37019,6 +37050,81 @@ function inspectDatasourceSchemaTool(client) {
         const header = { datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind } };
         return asBatch ? ok({ ...header, results }) : ok({ ...header, method: results[0].method, result: results[0].result });
       } catch (err) {
+        return fail(err);
+      }
+    }
+  };
+}
+
+// dist/tools/testDatasourceConnection.js
+var NOT_IMPLEMENTED = /testconnection method not implemented/i;
+function isForbidden(message) {
+  return /\(403\)/.test(message) || /forbidden/i.test(message);
+}
+function isNotFound(message) {
+  return /\(404\)/.test(message);
+}
+function testDatasourceConnectionTool(client) {
+  return {
+    name: "test_datasource_connection",
+    description: "Run ToolJet's own connection test for one ALREADY-CONNECTED datasource \u2014 the same check the datasource settings page performs. Uses the datasource's stored credentials; you never supply, see, or need them. Use it to distinguish a broken connection from a wrong query when a run fails, or to confirm a source before building on it. Returns supported:false for datasource kinds whose plugin does not implement a connection test (REST API, GraphQL, and most OAuth/HTTP integrations) \u2014 that is not a fault and says nothing about the connection. On a real failure, hand the returned settings_url to the user for repair; never enter credentials or save settings for them.",
+    inputSchema: {
+      version_id: external_exports.string().min(1),
+      datasource_id: external_exports.string().min(1)
+    },
+    async handler(args) {
+      try {
+        const datasource = (await client.listDatasources(args.version_id)).find((candidate) => candidate.id === args.datasource_id);
+        if (!datasource) {
+          return fail(new Error(`Datasource "${args.datasource_id}" is not available on version "${args.version_id}".`));
+        }
+        const header = {
+          datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind },
+          settings_url: datasource.settings_url
+        };
+        const details = await client.getDatasourceConnectionDetails(args.datasource_id);
+        const result = await client.testDatasourceConnection({
+          dataSourceId: datasource.id,
+          kind: details.kind || datasource.kind,
+          ...details.pluginId ? { pluginId: details.pluginId } : {},
+          options: details.options
+        });
+        const message = typeof result.message === "string" ? result.message : void 0;
+        if (message && NOT_IMPLEMENTED.test(message)) {
+          return ok({
+            ...header,
+            supported: false,
+            status: "unsupported",
+            message: `Datasource kind "${datasource.kind}" does not implement a connection test. This is not a failure and carries no information about the connection: verify it with a bounded read instead.`
+          });
+        }
+        if (result.status === "ok") {
+          return ok({ ...header, supported: true, status: "ok" });
+        }
+        return ok({
+          ...header,
+          supported: true,
+          status: "failed",
+          ...message ? { message: message.trim() } : {},
+          recovery: {
+            action: "open_datasource_settings",
+            url: datasource.settings_url,
+            instruction: "Ask the user to repair this connection in ToolJet. Never enter credentials, authorize OAuth, or save settings on their behalf."
+          }
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (isForbidden(message)) {
+          return ok({
+            datasource: { id: args.datasource_id },
+            supported: true,
+            status: "not_permitted",
+            message: "This ToolJet user is not permitted to test datasource connections (the ability is granted to admins, datasource create/delete holders, and users with editable/viewable datasource access). The connection itself was not tested."
+          });
+        }
+        if (isNotFound(message)) {
+          return fail(new Error(`ToolJet has no test-connection endpoint or no datasource "${args.datasource_id}" for this environment (${message}).`));
+        }
         return fail(err);
       }
     }
@@ -42132,6 +42238,7 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     insertRowsBatchTool(client),
     getDatasourceQuerySchemaTool(client),
     inspectDatasourceSchemaTool(client),
+    testDatasourceConnectionTool(client),
     prepareSqlDiscoveryQueriesTool(client),
     generateFormSchemaTool(client),
     getComponentCatalogTool(client),

--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -812,7 +812,14 @@ const datasourceRepair = `## Missing or broken datasource recovery
 
 \`list_workspaces\` returns \`datasources_url\`; \`list_datasources\` returns a direct \`settings_url\` for each source; failed query runs may return \`recovery:{action:"open_datasource_settings",url,instruction}\`.
 
-When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, test the connection, or save settings for the user. Wait for the user to confirm the repair, then refresh \`list_datasources\` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.`;
+When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh \`list_datasources\` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
+
+\`test_datasource_connection({version_id, datasource_id})\` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the \`status\` precisely:
+
+- \`ok\` — the connection works; a failing query is the query's fault.
+- \`failed\` — genuinely broken; hand over the returned \`recovery.url\` and stop.
+- \`unsupported\` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- \`not_permitted\` — this ToolJet user may not test connections. Also not a fault; say so and move on.`;
 const restApiGuidance = `## REST API queries
 
 For \`kind:"restapi"\`, fetch the contract for the intended HTTP method, but do not persist an \`operation\` option: REST queries are selected by \`method\`. \`headers\`, \`url_params\`, \`cookies\`, and structured \`body\` are arrays of two-item \`[key, value]\` tuples. For a raw body use \`body_toggle:true\` with \`raw_body\`; \`json_body\` is a legacy fallback for existing queries.

--- a/skill/references/datasources.md
+++ b/skill/references/datasources.md
@@ -6,7 +6,14 @@ Read this when selecting, connecting, introspecting, or authoring datasource que
 
 `list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source; failed query runs may return `recovery:{action:"open_datasource_settings",url,instruction}`.
 
-When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, test the connection, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
+When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
+
+`test_datasource_connection({version_id, datasource_id})` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the `status` precisely:
+
+- `ok` — the connection works; a failing query is the query's fault.
+- `failed` — genuinely broken; hand over the returned `recovery.url` and stop.
+- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 
 ### Large-data read safety
 

--- a/skills/tooljet-app-builder/references/datasources.md
+++ b/skills/tooljet-app-builder/references/datasources.md
@@ -6,7 +6,14 @@ Read this when selecting, connecting, introspecting, or authoring datasource que
 
 `list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source; failed query runs may return `recovery:{action:"open_datasource_settings",url,instruction}`.
 
-When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, test the connection, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
+When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
+
+`test_datasource_connection({version_id, datasource_id})` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the `status` precisely:
+
+- `ok` — the connection works; a failing query is the query's fault.
+- `failed` — genuinely broken; hand over the returned `recovery.url` and stop.
+- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 
 ### Large-data read safety
 

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -310,6 +310,33 @@ export interface InvokeDatasourceMethodParams {
   args?: Record<string, unknown>;
 }
 
+/** A saved datasource's stored connection configuration, as ToolJet holds it for one environment.
+ *
+ *  `options` values carry `credential_id` references for secrets rather than plaintext — ToolJet
+ *  dereferences them server-side. Nothing here is ever shown to the model. */
+export interface DatasourceConnectionDetails {
+  kind: string;
+  /** Present only for marketplace plugins; core datasources have none and must omit it. */
+  pluginId?: string;
+  options: Record<string, unknown>;
+}
+
+export interface TestDatasourceConnectionParams {
+  dataSourceId: string;
+  kind: string;
+  pluginId?: string;
+  options: Record<string, unknown>;
+  environmentId?: string;
+}
+
+/** ToolJet's own test-connection verdict. `status` is 'ok' or 'failed'; a plugin that does not
+ *  implement testConnection also arrives here as 'failed', which the tool separates out. */
+export interface ConnectionTestResult {
+  status: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
 export type EventSourceType = 'component' | 'data_query' | 'page' | 'table_column' | 'table_action';
 
 /** One event handler: a trigger on a component, query, page, or component sub-element + an action. */
@@ -427,6 +454,8 @@ export interface ToolJetClient {
   getQuery(queryId: string, versionId: string): Promise<QuerySummary>;
   runQuery(params: { queryId: string; versionId: string; environmentId?: string }): Promise<RunQueryResult>;
   invokeDatasourceMethod(params: InvokeDatasourceMethodParams): Promise<RunQueryResult>;
+  getDatasourceConnectionDetails(dataSourceId: string, environmentId?: string): Promise<DatasourceConnectionDetails>;
+  testDatasourceConnection(params: TestDatasourceConnectionParams): Promise<ConnectionTestResult>;
   listEvents(params: { appId: string; versionId: string; sourceId?: string }): Promise<EventSummary[]>;
   updateEvents(params: UpdateEventsParams): Promise<{ updated: number }>;
   deleteEvent(params: { appId: string; versionId: string; eventId: string }): Promise<{ deleted: boolean }>;
@@ -1725,6 +1754,57 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     return (await res.json()) as RunQueryResult;
   }
 
+  /** Read one saved datasource's stored connection configuration for an environment.
+   *
+   *  Deliberately NOT taken from listDatasources: that response passes through ToolJet's
+   *  decamelizeKeys, which rewrites option KEYS as well as envelope fields — `apiKey` becomes
+   *  `api_key` for the 18 kinds whose manifests use camelCase (openai, mssql `instanceName`,
+   *  cosmosdb `endPoint`, …). Posting those back would test a config the plugin cannot read and
+   *  report a healthy source as broken. This route returns the entity unmodified. */
+  async function getDatasourceConnectionDetails(
+    dataSourceId: string,
+    environmentId?: string
+  ): Promise<DatasourceConnectionDetails> {
+    const envId = environmentId ?? (await getDevelopmentEnvironmentId());
+    const res = await auth.authedFetch(
+      `/api/data-sources/${encodeURIComponent(dataSourceId)}/environment/${encodeURIComponent(envId)}`
+    );
+    await assertOk(res, 'getDatasourceConnectionDetails');
+    const body = (await res.json()) as Record<string, any>;
+    const pluginId = body.pluginId ?? body.plugin_id ?? undefined;
+    return {
+      kind: body.kind,
+      ...(pluginId ? { pluginId } : {}),
+      options: (body.options ?? {}) as Record<string, unknown>,
+    };
+  }
+
+  /** Run ToolJet's own connection test for a saved datasource — the same call the datasource
+   *  settings page makes. Options are the stored ones; a caller never supplies its own, so no
+   *  credential passes through this process. */
+  async function testDatasourceConnection(
+    params: TestDatasourceConnectionParams
+  ): Promise<ConnectionTestResult> {
+    const environmentId = params.environmentId ?? (await getDevelopmentEnvironmentId());
+    const res = await auth.authedFetch(
+      `/api/data-sources/${encodeURIComponent(params.dataSourceId)}/test-connection`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          kind: params.kind,
+          options: params.options,
+          environment_id: environmentId,
+          // ToolJet validates plugin_id as a UUID; core datasources have none, so it must be
+          // omitted rather than sent as null.
+          ...(params.pluginId ? { plugin_id: params.pluginId } : {}),
+        }),
+      }
+    );
+    await assertOk(res, 'testDatasourceConnection');
+    return (await res.json()) as ConnectionTestResult;
+  }
+
   async function listEvents(params: {
     appId: string;
     versionId: string;
@@ -1833,6 +1913,8 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     getQuery,
     runQuery,
     invokeDatasourceMethod,
+    getDatasourceConnectionDetails,
+    testDatasourceConnection,
     listEvents,
     updateEvents,
     deleteEvent,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -20,6 +20,7 @@ import { insertRowsBatchTool } from './insertRowsBatch.js';
 import { getComponentCatalogTool } from './getComponentCatalog.js';
 import { getDatasourceQuerySchemaTool } from './getDatasourceQuerySchema.js';
 import { inspectDatasourceSchemaTool } from './inspectDatasourceSchema.js';
+import { testDatasourceConnectionTool } from './testDatasourceConnection.js';
 import { prepareSqlDiscoveryQueriesTool } from './prepareSqlDiscoveryQueries.js';
 import { generateFormSchemaTool } from './generateFormSchema.js';
 import { getAppTool } from './getApp.js';
@@ -96,6 +97,7 @@ export function registerTools(
     insertRowsBatchTool(client),
     getDatasourceQuerySchemaTool(client),
     inspectDatasourceSchemaTool(client),
+    testDatasourceConnectionTool(client),
     prepareSqlDiscoveryQueriesTool(client),
     generateFormSchemaTool(client),
     getComponentCatalogTool(client),

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import type { ToolJetClient } from '../tooljetClient.js';
+import { ok, fail, type ToolDef } from './types.js';
+
+/**
+ * Four outcomes hide behind ToolJet's two-field verdict, and conflating them produces confident
+ * wrong advice. `testConnection` is optional on a plugin: 25 of 92 packages — every HTTP-passthrough
+ * and OAuth kind (restapi, graphql, stripe, hubspot, gmail, salesforce, …) — do not implement it,
+ * and ToolJet's util.service catches the resulting NotImplementedException and flattens it into a
+ * normal `{status:'failed'}`. Reported as-is, that reads as "your working Stripe source is down".
+ */
+const NOT_IMPLEMENTED = /testconnection method not implemented/i;
+
+/** Permission, not health: TEST_CONNECTION is granted to admins, datasource create/delete holders,
+ *  all-editable/all-viewable, and per-datasource configurable grants — but NOT to a bare builder. */
+function isForbidden(message: string): boolean {
+  return /\(403\)/.test(message) || /forbidden/i.test(message);
+}
+
+function isNotFound(message: string): boolean {
+  return /\(404\)/.test(message);
+}
+
+export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'test_datasource_connection',
+    description:
+      "Run ToolJet's own connection test for one ALREADY-CONNECTED datasource — the same check the " +
+      'datasource settings page performs. Uses the datasource\'s stored credentials; you never supply, ' +
+      'see, or need them. Use it to distinguish a broken connection from a wrong query when a run fails, ' +
+      'or to confirm a source before building on it. Returns supported:false for datasource kinds whose ' +
+      'plugin does not implement a connection test (REST API, GraphQL, and most OAuth/HTTP integrations) — ' +
+      'that is not a fault and says nothing about the connection. On a real failure, hand the returned ' +
+      'settings_url to the user for repair; never enter credentials or save settings for them.',
+    inputSchema: {
+      version_id: z.string().min(1),
+      datasource_id: z.string().min(1),
+    },
+    async handler(args: { version_id: string; datasource_id: string }) {
+      try {
+        const datasource = (await client.listDatasources(args.version_id)).find(
+          (candidate) => candidate.id === args.datasource_id
+        );
+        if (!datasource) {
+          return fail(
+            new Error(`Datasource "${args.datasource_id}" is not available on version "${args.version_id}".`)
+          );
+        }
+        const header = {
+          datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind },
+          settings_url: datasource.settings_url,
+        };
+
+        const details = await client.getDatasourceConnectionDetails(args.datasource_id);
+        const result = await client.testDatasourceConnection({
+          dataSourceId: datasource.id,
+          kind: details.kind || datasource.kind,
+          ...(details.pluginId ? { pluginId: details.pluginId } : {}),
+          options: details.options,
+        });
+
+        const message = typeof result.message === 'string' ? result.message : undefined;
+        if (message && NOT_IMPLEMENTED.test(message)) {
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message:
+              `Datasource kind "${datasource.kind}" does not implement a connection test. This is not a ` +
+              'failure and carries no information about the connection: verify it with a bounded read instead.',
+          });
+        }
+
+        if (result.status === 'ok') {
+          return ok({ ...header, supported: true, status: 'ok' });
+        }
+        return ok({
+          ...header,
+          supported: true,
+          status: 'failed',
+          ...(message ? { message: message.trim() } : {}),
+          recovery: {
+            action: 'open_datasource_settings',
+            url: datasource.settings_url,
+            instruction:
+              'Ask the user to repair this connection in ToolJet. Never enter credentials, authorize ' +
+              'OAuth, or save settings on their behalf.',
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // A permission denial is about the caller, not the datasource. Returned as a normal result
+        // so the model reports it accurately instead of announcing a broken source.
+        if (isForbidden(message)) {
+          return ok({
+            datasource: { id: args.datasource_id },
+            supported: true,
+            status: 'not_permitted',
+            message:
+              'This ToolJet user is not permitted to test datasource connections (the ability is granted to ' +
+              'admins, datasource create/delete holders, and users with editable/viewable datasource access). ' +
+              'The connection itself was not tested.',
+          });
+        }
+        if (isNotFound(message)) {
+          return fail(
+            new Error(
+              `ToolJet has no test-connection endpoint or no datasource "${args.datasource_id}" for this ` +
+                `environment (${message}).`
+            )
+          );
+        }
+        return fail(err);
+      }
+    },
+  };
+}

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -364,7 +364,12 @@ describe('generated skill — workspaces', () => {
     expect(skill).toMatch(/datasources_url.*settings_url.*recovery\.url/is);
     expect(skill).toMatch(/Open it in the built-in browser when available/i);
     expect(datasources).toMatch(/Navigation is the only automated action/i);
-    expect(datasources).toMatch(/never enter credentials, authorize OAuth, test the connection, or save settings/i);
+    expect(datasources).toMatch(/never enter credentials, authorize OAuth, or save settings/i);
+    // Testing a connection is no longer in the forbidden list: it became a governed read-only tool
+    // that never handles a credential. The rest of the handoff rule is unchanged.
+    expect(datasources).toMatch(/test_datasource_connection.*STORED credentials/is);
+    expect(datasources).toMatch(/unsupported.*says NOTHING about the connection/is);
+    expect(datasources).toMatch(/not_permitted.*not a fault/is);
     expect(datasources).toMatch(/Wait for the user to confirm.*retry at most one.*safe read/is);
     expect(workflows).toMatch(/list_workspaces\(\).*datasources_url/is);
     expect(workflows).toMatch(/list_datasources\(version_id\).*settings_url/is);

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolJetClient } from '../src/tooljetClient.js';
+import { testDatasourceConnectionTool } from '../src/tools/testDatasourceConnection.js';
+
+function textOf(result: { content: Array<{ text: string }> }): any {
+  return JSON.parse(result.content[0]!.text);
+}
+
+function clientWith(overrides: Partial<Record<string, unknown>> = {}): ToolJetClient {
+  return {
+    listDatasources: vi.fn().mockResolvedValue([
+      { id: 'pg1', name: 'Postgres', kind: 'postgresql', settings_url: 'http://tj/ws/data-sources/pg1' },
+    ]),
+    getDatasourceConnectionDetails: vi.fn().mockResolvedValue({
+      kind: 'postgresql',
+      options: { host: { value: 'localhost' }, password: { credential_id: 'cred-1' } },
+    }),
+    testDatasourceConnection: vi.fn().mockResolvedValue({ status: 'ok' }),
+    ...overrides,
+  } as unknown as ToolJetClient;
+}
+
+describe('test_datasource_connection tool', () => {
+  it('posts the stored options and reports a healthy connection', async () => {
+    const client = clientWith();
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(client.testDatasourceConnection).toHaveBeenCalledWith({
+      dataSourceId: 'pg1',
+      kind: 'postgresql',
+      options: { host: { value: 'localhost' }, password: { credential_id: 'cred-1' } },
+    });
+    expect(textOf(result)).toMatchObject({ status: 'ok', supported: true, datasource: { kind: 'postgresql' } });
+  });
+
+  it('omits plugin_id for core datasources and forwards it for marketplace plugins', async () => {
+    const client = clientWith({
+      getDatasourceConnectionDetails: vi.fn().mockResolvedValue({
+        kind: 'openai',
+        pluginId: '11111111-1111-1111-1111-111111111111',
+        options: { apiKey: { credential_id: 'cred-2' } },
+      }),
+    });
+    await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(client.testDatasourceConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: '11111111-1111-1111-1111-111111111111' })
+    );
+  });
+
+  it('reports an unsupported kind instead of a broken connection', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi
+        .fn()
+        .mockResolvedValue({ status: 'failed', message: 'testConnection method not implemented' }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed.supported).toBe(false);
+    expect(parsed.status).toBe('unsupported');
+    expect(parsed.message).toMatch(/does not implement a connection test/);
+    expect(parsed.recovery).toBeUndefined();
+  });
+
+  it('returns a repair handoff on a genuine connection failure', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi
+        .fn()
+        .mockResolvedValue({ status: 'failed', message: 'connection refused\n        ' }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed).toMatchObject({
+      status: 'failed',
+      supported: true,
+      message: 'connection refused',
+      recovery: { action: 'open_datasource_settings', url: 'http://tj/ws/data-sources/pg1' },
+    });
+  });
+
+  it('separates a permission denial from a connection fault', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi
+        .fn()
+        .mockRejectedValue(new Error('ToolJet testDatasourceConnection failed (403): Forbidden')),
+    });
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toMatchObject({ status: 'not_permitted' });
+  });
+
+  it('rejects a datasource that is not on this version', async () => {
+    const client = clientWith();
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'nope' });
+    expect(result.isError).toBe(true);
+    expect(client.testDatasourceConnection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Runs ToolJet's own connection check (POST /api/data-sources/:id/test-connection) for a saved datasource, so the agent can tell a broken connection apart from a wrong query instead of rewriting SQL against a source that is down.

Options come from the datasource's stored configuration, never from the caller, so no credential passes through this process — secrets stay `credential_id` references that ToolJet dereferences server-side.

Stored options are read from GET /api/data-sources/:id/environment/:envId rather than from list_datasources: that response passes through ToolJet's decamelizeKeys, which rewrites option KEYS as well as envelope fields. 18 datasource kinds use camelCase option keys (openai/anthropic/gemini/cohere/qdrant/pinecone `apiKey`, mssql `instanceName`, cosmosdb `endPoint`, mariadb `connectionLimit`, …), so posting those back would test a config the plugin cannot read and report a healthy source as broken. Costs one extra request; correct for all 92 kinds.

Four outcomes are kept distinct, because ToolJet flattens all of them into {status:'failed'} and conflating them produces confident wrong advice:

  ok             connection works — a failing query is the query's fault
  failed         genuinely broken — carries recovery.{action,url,instruction}
  unsupported    the plugin implements no connection test (25 of 92 packages:
                 restapi, graphql, stripe, hubspot, gmail, salesforce, …). Says
                 NOTHING about the connection; never reported as a fault.
  not_permitted  403 — TEST_CONNECTION is not granted to a bare builder. About
                 the caller, not the datasource, so it is returned as a normal
                 result rather than isError.

plugin_id is validated as a UUID by ToolJet, so it is omitted for core datasources rather than sent as null.

No ToolJet-side change is needed: the data-sources controller carries @InitModule(MODULES.GLOBAL_DATA_SOURCE), which is already inside PAT_BUNDLE.DATA, so the route is reachable on both the PAT and per-user-session credential paths.

The skill's datasource-recovery rule no longer forbids testing a connection — that is now a governed read-only tool. It still forbids entering credentials, authorizing OAuth, and saving settings on the user's behalf.