### PR TITLE
Feature: Let a request name its own ToolJet backend

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -24,7 +24,7 @@
       ],
       "env": {
         "TOOLJET_URL": "${TOOLJET_URL:-http://localhost:3000}",
-        "TOOLJET_APP_URL": "${TOOLJET_APP_URL:-http://localhost:8082}",
+        "TOOLJET_DEPLOYMENT_URL": "${TOOLJET_DEPLOYMENT_URL}",
         "TOOLJET_PAT": "${TOOLJET_PAT}"
       }
     }

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 TOOLJET_URL=http://localhost:3000
-TOOLJET_APP_URL=http://localhost:8082
+
+# Only needed if the UI is served from a different origin than TOOLJET_URL — it defaults to
+# TOOLJET_URL otherwise, which covers most self-hosted deployments (one origin for both).
+# TOOLJET_DEPLOYMENT_URL=http://localhost:8082
 
 # Personal access token. Create one in ToolJet under Settings → Access tokens, in the workspace you
 # want this server to act on. A PAT session is pinned to that workspace and can reach no other.

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,7 @@
       ],
       "env": {
         "TOOLJET_URL": "${TOOLJET_URL}",
-        "TOOLJET_APP_URL": "${TOOLJET_APP_URL}",
+        "TOOLJET_DEPLOYMENT_URL": "${TOOLJET_DEPLOYMENT_URL}",
         "TOOLJET_PAT": "${TOOLJET_PAT}"
       }
     }

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ npm run build               # compiles to dist/
 
 `.env`:
 ```
-TOOLJET_URL=http://localhost:3000        # backend API origin
-TOOLJET_APP_URL=http://localhost:8082    # frontend origin (for app links)
+TOOLJET_URL=http://localhost:3000        # your ToolJet deployment
 TOOLJET_PAT=tj_pat_...                   # Settings -> Access tokens, in the target workspace
+# Only needed if the UI is served from a different origin than TOOLJET_URL (defaults to it otherwise):
+# TOOLJET_DEPLOYMENT_URL=http://localhost:8082
 ```
 
 The default MCP profile keeps tool selection compact by exposing batch create tools only; every batch accepts a single item. Older clients can restore the redundant singular aliases with `TOOLJET_INCLUDE_LEGACY_SINGULAR_TOOLS=true`.
@@ -49,7 +50,8 @@ Before launching Codex, provide the same credentials used by the standalone MCP 
 export TOOLJET_PAT="tj_pat_..."
 # optional, if not localhost:
 export TOOLJET_URL="https://your-instance.tooljet.com"
-export TOOLJET_APP_URL="https://your-instance.tooljet.com"
+# only needed if the UI is served from a different origin than TOOLJET_URL:
+# export TOOLJET_DEPLOYMENT_URL="https://app.your-instance.tooljet.com"
 ```
 
 The plugin passes these environment variables to the MCP process; it does not store or change the
@@ -66,8 +68,9 @@ args = ["/absolute/path/to/tooljet-mcp/bundle/index.js"]
 
 [mcp_servers.tooljet.env]
 TOOLJET_URL = "http://localhost:3000"
-TOOLJET_APP_URL = "http://localhost:8082"
 TOOLJET_PAT = "tj_pat_..."
+# only if the UI is served from a different origin than TOOLJET_URL:
+# TOOLJET_DEPLOYMENT_URL = "http://localhost:8082"
 ```
 
 Then install the skill so Codex knows how to drive the tools: copy the complete `skill/` directory into your Codex skills directory (or use `npm run sync:skill`). Its compact entry point progressively loads focused references for tables, forms, events, datasources, security, and QA.
@@ -113,9 +116,10 @@ format, which VS Code, Copilot CLI and the Copilot app share. Install with **Cha
 From Source** (or the Plugins tab of the Agent Customizations editor) and give it this repo's URL.
 
 Skills are discovered from `skills/`, so the same `skills/tooljet-app-builder` that Claude Code loads
-is picked up here with no second copy. Set `TOOLJET_URL`, `TOOLJET_APP_URL` and `TOOLJET_PAT` in the
-environment the editor launches from; unset or blank values fall back to the server's own defaults,
-and a missing token is reported at handshake rather than killing the server.
+is picked up here with no second copy. Set `TOOLJET_URL` and `TOOLJET_PAT` in the environment the
+editor launches from (`TOOLJET_DEPLOYMENT_URL` too, only if the UI is on a different origin than
+`TOOLJET_URL`); unset or blank values fall back to the server's own defaults, and a missing token is
+reported at handshake rather than killing the server.
 
 ## Install as a Claude Code plugin
 
@@ -132,12 +136,13 @@ Or via the marketplace, which lets you get updates:
 ```
 For local development you can also install from a path: `/plugin install path:/absolute/path/to/tooljet-mcp`.
 
-**Provide credentials.** A plugin cannot prompt for secrets, so the MCP server reads them from your environment (the `TOOLJET_URL`/`TOOLJET_APP_URL` default to localhost). Before launching Claude Code:
+**Provide credentials.** A plugin cannot prompt for secrets, so the MCP server reads them from your environment (`TOOLJET_URL` defaults to localhost; `TOOLJET_DEPLOYMENT_URL` defaults to `TOOLJET_URL`). Before launching Claude Code:
 ```bash
 export TOOLJET_PAT="tj_pat_..."
 # optional, if not localhost:
 export TOOLJET_URL="https://your-instance.tooljet.com"
-export TOOLJET_APP_URL="https://your-instance.tooljet.com"
+# only needed if the UI is served from a different origin than TOOLJET_URL:
+# export TOOLJET_DEPLOYMENT_URL="https://app.your-instance.tooljet.com"
 ```
 If either credential is missing, the server exits during startup with a clear required-variable error. Set both and restart.
 

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33241,7 +33241,7 @@ function loadConfig(identity) {
   const explicitAppUrl = env("TOOLJET_DEPLOYMENT_URL") ?? env("TOOLJET_APP_URL");
   if (identity) {
     const apiUrl2 = identity.apiUrl ?? staticApiUrl;
-    const appUrl2 = explicitAppUrl ?? identity.apiUrl ?? staticApiUrl;
+    const appUrl2 = explicitAppUrl ?? identity.apiUrl ?? explicitApiUrl ?? "http://localhost:8082";
     if (identity.pat)
       return { apiUrl: apiUrl2, appUrl: appUrl2, pat: identity.pat };
     return {

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -7021,7 +7021,8 @@ var require_dist = __commonJS({
 
 // dist/index.js
 import { createServer } from "node:http";
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { fileURLToPath as fileURLToPath4 } from "node:url";
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
@@ -42442,7 +42443,17 @@ async function main() {
   }
   await server.connect(new StdioServerTransport());
 }
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+function isEntrypoint() {
+  const invoked = process.argv[1];
+  if (!invoked)
+    return false;
+  try {
+    return realpathSync(invoked) === realpathSync(fileURLToPath4(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+if (isEntrypoint()) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33161,9 +33161,23 @@ var SESSION_TOKEN_HEADER = "x-tooljet-session";
 var WORKSPACE_ID_HEADER = "x-tooljet-workspace-id";
 var WORKSPACE_SLUG_HEADER = "x-tooljet-workspace-slug";
 var PAT_HEADER = "x-tooljet-pat";
+var BASE_URL_HEADER = "x-tooljet-url";
+var ALLOWED_API_ORIGINS_VAR = "MCP_ALLOWED_API_ORIGINS";
 function env(name) {
   const value = process.env[name]?.trim();
   return value ? value : void 0;
+}
+function allowedApiOrigins() {
+  const raw = env(ALLOWED_API_ORIGINS_VAR);
+  if (!raw)
+    return [];
+  return raw.split(",").map((entry) => entry.trim()).filter(Boolean).map((entry) => {
+    try {
+      return new URL(entry).origin;
+    } catch {
+      throw new Error(`${ALLOWED_API_ORIGINS_VAR} contains an entry that is not a valid URL: "${entry}".`);
+    }
+  });
 }
 function readHeader(headers, name) {
   const raw = headers[name] ?? headers[name.toLowerCase()];
@@ -33171,42 +33185,65 @@ function readHeader(headers, name) {
   const trimmed = value?.trim();
   return trimmed ? trimmed : void 0;
 }
+function validateApiUrl(raw) {
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${BASE_URL_HEADER} must be a valid absolute URL.`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`${BASE_URL_HEADER} must use https.`);
+  }
+  if (parsed.search || parsed.hash || parsed.username || parsed.password) {
+    throw new Error(`${BASE_URL_HEADER} must carry no query, hash, or credentials.`);
+  }
+  if (!allowedApiOrigins().includes(parsed.origin)) {
+    throw new Error(`${BASE_URL_HEADER} origin "${parsed.origin}" is not in ${ALLOWED_API_ORIGINS_VAR}. Add it to that comma-separated list to let this server write into that backend.`);
+  }
+  const path = parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/$/, "");
+  return parsed.origin + path;
+}
 function identityFromHeaders(headers, { allowPat = true } = {}) {
   const sessionToken = readHeader(headers, SESSION_TOKEN_HEADER);
   const workspaceId = readHeader(headers, WORKSPACE_ID_HEADER);
   const pat = readHeader(headers, PAT_HEADER);
+  const rawApiUrl = readHeader(headers, BASE_URL_HEADER);
+  const apiUrl = rawApiUrl ? validateApiUrl(rawApiUrl) : void 0;
   if (pat) {
     if (!allowPat) {
       throw new Error(`${PAT_HEADER} is not accepted by this server. It acts only on behalf of a signed-in user: send ${SESSION_TOKEN_HEADER} with ${WORKSPACE_ID_HEADER}.`);
     }
     if (sessionToken)
       throw new Error(`Send either ${PAT_HEADER} or ${SESSION_TOKEN_HEADER}, not both.`);
-    return { pat };
+    return { pat, apiUrl };
   }
   if (!sessionToken && !workspaceId)
-    return void 0;
+    return apiUrl ? { apiUrl } : void 0;
   if (!sessionToken) {
     throw new Error(`${WORKSPACE_ID_HEADER} was sent without ${SESSION_TOKEN_HEADER}.`);
   }
   if (!workspaceId) {
     throw new Error(`${SESSION_TOKEN_HEADER} was sent without ${WORKSPACE_ID_HEADER}.`);
   }
-  return { sessionToken, workspaceId, workspaceSlug: readHeader(headers, WORKSPACE_SLUG_HEADER) };
+  return { sessionToken, workspaceId, workspaceSlug: readHeader(headers, WORKSPACE_SLUG_HEADER), apiUrl };
 }
 function loadConfig(identity) {
-  const apiUrl = env("TOOLJET_URL") ?? "http://localhost:3000";
+  const staticApiUrl = env("TOOLJET_URL") ?? "http://localhost:3000";
   const appUrl = env("TOOLJET_APP_URL") ?? "http://localhost:8082";
   if (identity) {
+    const apiUrl2 = identity.apiUrl ?? staticApiUrl;
     if (identity.pat)
-      return { apiUrl, appUrl, pat: identity.pat };
+      return { apiUrl: apiUrl2, appUrl, pat: identity.pat };
     return {
-      apiUrl,
+      apiUrl: apiUrl2,
       appUrl,
       sessionToken: identity.sessionToken,
       workspaceId: identity.workspaceId,
       workspaceSlug: identity.workspaceSlug
     };
   }
+  const apiUrl = staticApiUrl;
   const pat = env("TOOLJET_PAT");
   const sessionToken = env("TOOLJET_SESSION_TOKEN");
   const workspaceId = env("TOOLJET_WORKSPACE_ID");
@@ -42322,9 +42359,16 @@ function bearerValue(authHeader) {
 async function serveHttp() {
   const port = Number(process.env.PORT ?? 8787);
   const sharedToken = process.env.MCP_SHARED_TOKEN;
+  try {
+    allowedApiOrigins();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
+  }
   const gatewayMode = Boolean(sharedToken);
   const host = process.env.MCP_HTTP_HOST ?? (gatewayMode ? "0.0.0.0" : "127.0.0.1");
   const requireUserSession = gatewayMode && (/^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_USER_SESSION ?? "") || !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN));
+  const requireRequestUrl = gatewayMode && /^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_REQUEST_URL ?? "");
   const httpServer = createServer((req, res) => {
     if (gatewayMode && !checkBearerToken(req.headers.authorization, sharedToken)) {
       res.writeHead(401, { "Content-Type": "text/plain" }).end("Unauthorized");
@@ -42343,11 +42387,16 @@ async function serveHttp() {
       if (bearer)
         identity = { pat: bearer };
     }
-    if (!identity && requireUserSession) {
+    const hasUserCredential = Boolean(identity?.pat || identity?.sessionToken);
+    if (!hasUserCredential && requireUserSession) {
       res.writeHead(400, { "Content-Type": "text/plain" }).end(`This server acts only on behalf of a signed-in user: send the ${SESSION_TOKEN_HEADER} header (with x-tooljet-workspace-id). Refusing rather than using a shared identity.`);
       return;
     }
-    if (!gatewayMode && !identity && !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN)) {
+    if (!identity?.apiUrl && requireRequestUrl) {
+      res.writeHead(400, { "Content-Type": "text/plain" }).end(`This server acts only on the backend named in the request: send the ${BASE_URL_HEADER} header. Refusing rather than falling back to a fixed TOOLJET_URL.`);
+      return;
+    }
+    if (!gatewayMode && !hasUserCredential && !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN)) {
       res.writeHead(401, { "Content-Type": "text/plain" }).end(`No ToolJet credential. Send your personal access token as \`Authorization: Bearer <token>\` or in the ${PAT_HEADER} header, or set TOOLJET_PAT on this server. Create a token in ToolJet under Settings \u2192 Access tokens.`);
       return;
     }

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -7021,6 +7021,7 @@ var require_dist = __commonJS({
 
 // dist/index.js
 import { createServer } from "node:http";
+import { pathToFileURL } from "node:url";
 
 // node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
@@ -42441,7 +42442,7 @@ async function main() {
   }
   await server.connect(new StdioServerTransport());
 }
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33231,20 +33231,22 @@ function identityFromHeaders(headers, { allowPat = true } = {}) {
 function loadConfig(identity) {
   const explicitApiUrl = env("TOOLJET_URL");
   const staticApiUrl = explicitApiUrl ?? "http://localhost:3000";
-  const appUrl = env("TOOLJET_DEPLOYMENT_URL") ?? env("TOOLJET_APP_URL") ?? explicitApiUrl ?? "http://localhost:8082";
+  const explicitAppUrl = env("TOOLJET_DEPLOYMENT_URL") ?? env("TOOLJET_APP_URL");
   if (identity) {
     const apiUrl2 = identity.apiUrl ?? staticApiUrl;
+    const appUrl2 = explicitAppUrl ?? identity.apiUrl ?? staticApiUrl;
     if (identity.pat)
-      return { apiUrl: apiUrl2, appUrl, pat: identity.pat };
+      return { apiUrl: apiUrl2, appUrl: appUrl2, pat: identity.pat };
     return {
       apiUrl: apiUrl2,
-      appUrl,
+      appUrl: appUrl2,
       sessionToken: identity.sessionToken,
       workspaceId: identity.workspaceId,
       workspaceSlug: identity.workspaceSlug
     };
   }
   const apiUrl = staticApiUrl;
+  const appUrl = explicitAppUrl ?? explicitApiUrl ?? "http://localhost:8082";
   const pat = env("TOOLJET_PAT");
   const sessionToken = env("TOOLJET_SESSION_TOKEN");
   const workspaceId = env("TOOLJET_WORKSPACE_ID");

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33174,11 +33174,16 @@ function allowedApiOrigins() {
   if (!raw)
     return [];
   return raw.split(",").map((entry) => entry.trim()).filter(Boolean).map((entry) => {
+    let parsed;
     try {
-      return new URL(entry).origin;
+      parsed = new URL(entry);
     } catch {
       throw new Error(`${ALLOWED_API_ORIGINS_VAR} contains an entry that is not a valid URL: "${entry}".`);
     }
+    if (parsed.protocol !== "https:") {
+      throw new Error(`${ALLOWED_API_ORIGINS_VAR} entry "${entry}" must use https \u2014 it could never match a request.`);
+    }
+    return parsed.origin;
   });
 }
 function readHeader(headers, name) {

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33229,8 +33229,9 @@ function identityFromHeaders(headers, { allowPat = true } = {}) {
   return { sessionToken, workspaceId, workspaceSlug: readHeader(headers, WORKSPACE_SLUG_HEADER), apiUrl };
 }
 function loadConfig(identity) {
-  const staticApiUrl = env("TOOLJET_URL") ?? "http://localhost:3000";
-  const appUrl = env("TOOLJET_APP_URL") ?? "http://localhost:8082";
+  const explicitApiUrl = env("TOOLJET_URL");
+  const staticApiUrl = explicitApiUrl ?? "http://localhost:3000";
+  const appUrl = env("TOOLJET_DEPLOYMENT_URL") ?? env("TOOLJET_APP_URL") ?? explicitApiUrl ?? "http://localhost:8082";
   if (identity) {
     const apiUrl2 = identity.apiUrl ?? staticApiUrl;
     if (identity.pat)

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -42359,17 +42359,9 @@ function bearerValue(authHeader) {
 }
 
 // dist/index.js
-async function serveHttp() {
-  const port = Number(process.env.PORT ?? 8787);
+function createGatewayHttpServer() {
   const sharedToken = process.env.MCP_SHARED_TOKEN;
-  try {
-    allowedApiOrigins();
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
-  }
   const gatewayMode = Boolean(sharedToken);
-  const host = process.env.MCP_HTTP_HOST ?? (gatewayMode ? "0.0.0.0" : "127.0.0.1");
   const requireUserSession = gatewayMode && (/^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_USER_SESSION ?? "") || !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN));
   const requireRequestUrl = gatewayMode && /^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_REQUEST_URL ?? "");
   const httpServer = createServer((req, res) => {
@@ -42416,6 +42408,18 @@ async function serveHttp() {
       }
     });
   });
+  return { server: httpServer, gatewayMode };
+}
+async function serveHttp() {
+  const port = Number(process.env.PORT ?? 8787);
+  try {
+    allowedApiOrigins();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
+  }
+  const { server: httpServer, gatewayMode } = createGatewayHttpServer();
+  const host = process.env.MCP_HTTP_HOST ?? (gatewayMode ? "0.0.0.0" : "127.0.0.1");
   await new Promise((resolve3, reject) => {
     httpServer.once("error", reject);
     httpServer.listen(port, host, resolve3);
@@ -42437,7 +42441,12 @@ async function main() {
   }
   await server.connect(new StdioServerTransport());
 }
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+export {
+  createGatewayHttpServer
+};

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -78,7 +78,7 @@ Headers: Cookie + tj-workspace-id
   "editing_version": { "id": "9656402d-..." },        // ← version_id to author on
   "pages": [ { "id": "6478536b-...", "name": "Home", "index": 1 } ] }  // ← home_page_id = the 'Home' page
 ```
-**`create_app` flow:** POST /apps → get `app_id`; GET /apps/:app_id → `version_id = editing_version.id`, `home_page_id = pages.find(name=='Home').id`. It returns `editor_url = ${TOOLJET_APP_URL}/${workspaceSlug}/apps/${appSlug}`, `viewer_url = ${TOOLJET_APP_URL}/applications/${appId}/${homeHandle}?env=development&version=${editingVersionName}`, and the backward-compatible `app_url` editor alias.
+**`create_app` flow:** POST /apps → get `app_id`; GET /apps/:app_id → `version_id = editing_version.id`, `home_page_id = pages.find(name=='Home').id`. It returns `editor_url = ${appUrl}/${workspaceSlug}/apps/${appSlug}`, `viewer_url = ${appUrl}/applications/${appId}/${homeHandle}?env=development&version=${editingVersionName}`, and the backward-compatible `app_url` editor alias.
 
 ---
 

--- a/mcp.json
+++ b/mcp.json
@@ -7,7 +7,7 @@
       ],
       "env": {
         "TOOLJET_URL": "${TOOLJET_URL}",
-        "TOOLJET_APP_URL": "${TOOLJET_APP_URL}",
+        "TOOLJET_DEPLOYMENT_URL": "${TOOLJET_DEPLOYMENT_URL}",
         "TOOLJET_PAT": "${TOOLJET_PAT}"
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,11 +48,22 @@ export const WORKSPACE_ID_HEADER = 'x-tooljet-workspace-id';
 export const WORKSPACE_SLUG_HEADER = 'x-tooljet-workspace-slug';
 export const PAT_HEADER = 'x-tooljet-pat';
 export const BASE_URL_HEADER = 'x-tooljet-url';
+/** Comma-separated https origins this server will accept as a request-named target. */
+export const ALLOWED_API_ORIGINS_VAR = 'MCP_ALLOWED_API_ORIGINS';
 
 /** An environment variable, or undefined when unset OR blank. */
 function env(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value ? value : undefined;
+}
+
+function allowedApiOrigins(): string[] {
+  const raw = env(ALLOWED_API_ORIGINS_VAR);
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 type HeaderBag = Record<string, string | string[] | undefined>;
@@ -67,13 +78,16 @@ function readHeader(headers: HeaderBag, name: string): string | undefined {
 /**
  * Validate the request-supplied target origin, or throw.
  *
- * Gets the caller's session/PAT attached and sent straight to it (auth.ts), so this closes the
- * parse+scheme gap (garbage input, http downgrade) — not a host allowlist, still trusts any https host.
+ * Gets the caller's session/PAT attached and sent straight to it (auth.ts) — a bearer-grade
+ * credential, not just traffic. https alone does not make a host trustworthy: an attacker's own
+ * domain has a valid cert too. So beyond parse+scheme (garbage input, http downgrade), the origin
+ * must also appear in MCP_ALLOWED_API_ORIGINS. Unset means empty, not "allow anything" — a shared
+ * deployment must opt in to which backends it will ever write into.
  *
  * A path prefix is allowed (not just a bare origin): ToolJet supports SUB_PATH hosting, so a
  * self-hosted customer reverse-proxied at e.g. https://tj.example.com/tooljet is a legitimate target,
- * not a malformed one. Query, hash, and credentials are still rejected — nothing downstream needs
- * them, and each one would name a place the caller has no ordinary reason to send this URL to.
+ * not a malformed one. The allowlist matches on origin only — the path is the operator's own
+ * reverse-proxy detail, not the trust boundary. Query, hash, and credentials are rejected outright.
  */
 function validateApiUrl(raw: string): string {
   let parsed: URL;
@@ -87,6 +101,12 @@ function validateApiUrl(raw: string): string {
   }
   if (parsed.search || parsed.hash || parsed.username || parsed.password) {
     throw new Error(`${BASE_URL_HEADER} must carry no query, hash, or credentials.`);
+  }
+  if (!allowedApiOrigins().includes(parsed.origin)) {
+    throw new Error(
+      `${BASE_URL_HEADER} origin "${parsed.origin}" is not in ${ALLOWED_API_ORIGINS_VAR}. Add it to that ` +
+        'comma-separated list to let this server write into that backend.'
+    );
   }
   // A trailing slash is cosmetic; normalize it away so "https://x.com/tooljet" and
   // "https://x.com/tooljet/" resolve to the same target instead of being treated as different ones.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 export interface Config {
   apiUrl: string;
+  /** Where a human opens ToolJet in a browser — used only to build user-facing links (a datasource's
+   *  settings page, an app's editor/viewer URL). Most self-hosted instances serve the API and the UI
+   *  from the same origin, so this defaults to `apiUrl` rather than requiring a second setting. */
   appUrl: string;
   /** Personal access token. Scoped, revocable, and works on SSO-only instances. The token also
    *  determines the workspace: a PAT session is pinned to the workspace the token was issued in and
@@ -187,8 +190,14 @@ export function identityFromHeaders(
 export function loadConfig(identity?: RequestIdentity): Config {
   // `??` is wrong here: a plugin host substitutes an unset ${VAR} as an empty string, which is not
   // nullish, so it would beat the default and every request would go to "". Treat blank as unset.
-  const staticApiUrl = env('TOOLJET_URL') ?? 'http://localhost:3000';
-  const appUrl = env('TOOLJET_APP_URL') ?? 'http://localhost:8082';
+  const explicitApiUrl = env('TOOLJET_URL');
+  const staticApiUrl = explicitApiUrl ?? 'http://localhost:3000';
+  // TOOLJET_APP_URL is the old name — "app" read as "one ToolJet app" more often than "the ToolJet
+  // deployment", which is what this actually is. TOOLJET_DEPLOYMENT_URL is preferred; the old name
+  // keeps working so nobody's existing config breaks. Falls back to TOOLJET_URL (only when that was
+  // actually set, not its own localhost default) rather than requiring a second URL for the common
+  // case where the same origin serves both — a self-hosted instance behind one reverse proxy.
+  const appUrl = env('TOOLJET_DEPLOYMENT_URL') ?? env('TOOLJET_APP_URL') ?? explicitApiUrl ?? 'http://localhost:8082';
 
   if (identity) {
     // The request's own apiUrl wins when present — same precedence as the session/PAT identity

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,11 +77,19 @@ export function allowedApiOrigins(): string[] {
     .map((entry) => entry.trim())
     .filter(Boolean)
     .map((entry) => {
+      let parsed: URL;
       try {
-        return new URL(entry).origin;
+        parsed = new URL(entry);
       } catch {
         throw new Error(`${ALLOWED_API_ORIGINS_VAR} contains an entry that is not a valid URL: "${entry}".`);
       }
+      // A request's origin is required to be https (validateApiUrl) before it ever reaches this
+      // allowlist, so a non-https entry here — a typo, e.g. "http://" — could never match anything.
+      // Silently keeping it would leave the operator with a dead entry and no signal it's wrong.
+      if (parsed.protocol !== 'https:') {
+        throw new Error(`${ALLOWED_API_ORIGINS_VAR} entry "${entry}" must use https — it could never match a request.`);
+      }
+      return parsed.origin;
     });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,7 +220,12 @@ export function loadConfig(identity?: RequestIdentity): Config {
     // static config: a shared server acting for many different ToolJet backends has no single static
     // app URL that could ever be right for all of them. Most self-hosted instances serve the API and
     // the UI from the same origin, so the request's own apiUrl is the right default here too.
-    const appUrl = explicitAppUrl ?? identity.apiUrl ?? staticApiUrl;
+    //
+    // Falls through to explicitApiUrl, NOT staticApiUrl: staticApiUrl silently includes apiUrl's own
+    // internal localhost:3000 default, which would make an unconfigured deployment's appUrl land on
+    // the API's dev port instead of the UI's (localhost:8082) — the exact default the no-identity
+    // branch below already gets right. Only a genuinely-set TOOLJET_URL should stand in for appUrl.
+    const appUrl = explicitAppUrl ?? identity.apiUrl ?? explicitApiUrl ?? 'http://localhost:8082';
 
     if (identity.pat) return { apiUrl, appUrl, pat: identity.pat };
     return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,12 +36,18 @@ export interface RequestIdentity {
    *  the agent's own, so the server holds no credential and every write is attributed to the token's
    *  owner. Mutually exclusive with `sessionToken` — see identityFromHeaders. */
   pat?: string;
+  /** The calling ToolJet instance's own API origin, sent per request. One shared MCP server (staging,
+   *  cloud) can act on behalf of many different ToolJet backends — self-hosted and cloud alike — so
+   *  the target can't be this process's own fixed TOOLJET_URL. Wins over that static value when
+   *  present — see loadConfig. */
+  apiUrl?: string;
 }
 
 export const SESSION_TOKEN_HEADER = 'x-tooljet-session';
 export const WORKSPACE_ID_HEADER = 'x-tooljet-workspace-id';
 export const WORKSPACE_SLUG_HEADER = 'x-tooljet-workspace-slug';
 export const PAT_HEADER = 'x-tooljet-pat';
+export const BASE_URL_HEADER = 'x-tooljet-url';
 
 /** An environment variable, or undefined when unset OR blank. */
 function env(name: string): string | undefined {
@@ -73,6 +79,7 @@ export function identityFromHeaders(
   const sessionToken = readHeader(headers, SESSION_TOKEN_HEADER);
   const workspaceId = readHeader(headers, WORKSPACE_ID_HEADER);
   const pat = readHeader(headers, PAT_HEADER);
+  const apiUrl = readHeader(headers, BASE_URL_HEADER);
 
   if (pat) {
     /* A PAT names whoever owns it and lives for weeks; a session names the person this request is
@@ -90,10 +97,10 @@ export function identityFromHeaders(
     // mechanism exists to prevent, so refuse rather than silently prefer one.
     if (sessionToken) throw new Error(`Send either ${PAT_HEADER} or ${SESSION_TOKEN_HEADER}, not both.`);
     // A PAT is pinned to the workspace it was issued in, so unlike a session it needs no companion.
-    return { pat };
+    return { pat, apiUrl };
   }
 
-  if (!sessionToken && !workspaceId) return undefined;
+  if (!sessionToken && !workspaceId) return apiUrl ? { apiUrl } : undefined;
   if (!sessionToken) {
     throw new Error(`${WORKSPACE_ID_HEADER} was sent without ${SESSION_TOKEN_HEADER}.`);
   }
@@ -101,7 +108,7 @@ export function identityFromHeaders(
     throw new Error(`${SESSION_TOKEN_HEADER} was sent without ${WORKSPACE_ID_HEADER}.`);
   }
 
-  return { sessionToken, workspaceId, workspaceSlug: readHeader(headers, WORKSPACE_SLUG_HEADER) };
+  return { sessionToken, workspaceId, workspaceSlug: readHeader(headers, WORKSPACE_SLUG_HEADER), apiUrl };
 }
 
 /**
@@ -113,10 +120,26 @@ export function identityFromHeaders(
 export function loadConfig(identity?: RequestIdentity): Config {
   // `??` is wrong here: a plugin host substitutes an unset ${VAR} as an empty string, which is not
   // nullish, so it would beat the default and every request would go to "". Treat blank as unset.
-  const apiUrl = env('TOOLJET_URL') ?? 'http://localhost:3000';
+  const staticApiUrl = env('TOOLJET_URL') ?? 'http://localhost:3000';
   const appUrl = env('TOOLJET_APP_URL') ?? 'http://localhost:8082';
 
   if (identity) {
+    // The request's own apiUrl wins when present — same precedence as the session/PAT identity
+    // above it. One shared server must be able to act on many different ToolJet backends; the
+    // static TOOLJET_URL is only ever a fallback for it, never the source of truth.
+    const apiUrl = identity.apiUrl ?? staticApiUrl;
+
+    // MCP_REQUIRE_REQUEST_URL mirrors MCP_REQUIRE_USER_SESSION: a deployment that also has
+    // TOOLJET_URL set would otherwise silently fall back to it the moment the caller forgot the
+    // header, and every build would still succeed — just written into the wrong backend. Refuse
+    // instead of guessing.
+    if (!identity.apiUrl && /^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_REQUEST_URL ?? '')) {
+      throw new Error(
+        `This server acts only on the backend named in the request: send the ${BASE_URL_HEADER} ` +
+          'header. Refusing rather than falling back to a fixed TOOLJET_URL.'
+      );
+    }
+
     if (identity.pat) return { apiUrl, appUrl, pat: identity.pat };
     return {
       apiUrl,
@@ -126,6 +149,8 @@ export function loadConfig(identity?: RequestIdentity): Config {
       workspaceSlug: identity.workspaceSlug,
     };
   }
+
+  const apiUrl = staticApiUrl;
 
   const pat = env('TOOLJET_PAT');
   const sessionToken = env('TOOLJET_SESSION_TOKEN');

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,11 @@ function readHeader(headers: HeaderBag, name: string): string | undefined {
  *
  * Gets the caller's session/PAT attached and sent straight to it (auth.ts), so this closes the
  * parse+scheme gap (garbage input, http downgrade) — not a host allowlist, still trusts any https host.
+ *
+ * A path prefix is allowed (not just a bare origin): ToolJet supports SUB_PATH hosting, so a
+ * self-hosted customer reverse-proxied at e.g. https://tj.example.com/tooljet is a legitimate target,
+ * not a malformed one. Query, hash, and credentials are still rejected — nothing downstream needs
+ * them, and each one would name a place the caller has no ordinary reason to send this URL to.
  */
 function validateApiUrl(raw: string): string {
   let parsed: URL;
@@ -80,16 +85,13 @@ function validateApiUrl(raw: string): string {
   if (parsed.protocol !== 'https:') {
     throw new Error(`${BASE_URL_HEADER} must use https.`);
   }
-  if (
-    (parsed.pathname !== '' && parsed.pathname !== '/') ||
-    parsed.search ||
-    parsed.hash ||
-    parsed.username ||
-    parsed.password
-  ) {
-    throw new Error(`${BASE_URL_HEADER} must be a bare origin (scheme + host only, no path/query/credentials).`);
+  if (parsed.search || parsed.hash || parsed.username || parsed.password) {
+    throw new Error(`${BASE_URL_HEADER} must carry no query, hash, or credentials.`);
   }
-  return parsed.origin;
+  // A trailing slash is cosmetic; normalize it away so "https://x.com/tooljet" and
+  // "https://x.com/tooljet/" resolve to the same target instead of being treated as different ones.
+  const path = parsed.pathname === '/' ? '' : parsed.pathname.replace(/\/$/, '');
+  return parsed.origin + path;
 }
 
 /**
@@ -156,18 +158,12 @@ export function loadConfig(identity?: RequestIdentity): Config {
     // The request's own apiUrl wins when present — same precedence as the session/PAT identity
     // above it. One shared server must be able to act on many different ToolJet backends; the
     // static TOOLJET_URL is only ever a fallback for it, never the source of truth.
+    //
+    // MCP_REQUIRE_REQUEST_URL is enforced in index.ts, not here: this function can't tell a genuine
+    // stdio call (identity omitted, one operator, static URL is correct) apart from an HTTP request
+    // that simply sent no headers (identity also arrives as undefined) — only the HTTP layer that
+    // built `identity` from a real request knows which case it is.
     const apiUrl = identity.apiUrl ?? staticApiUrl;
-
-    // MCP_REQUIRE_REQUEST_URL mirrors MCP_REQUIRE_USER_SESSION: a deployment that also has
-    // TOOLJET_URL set would otherwise silently fall back to it the moment the caller forgot the
-    // header, and every build would still succeed — just written into the wrong backend. Refuse
-    // instead of guessing.
-    if (!identity.apiUrl && /^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_REQUEST_URL ?? '')) {
-      throw new Error(
-        `This server acts only on the backend named in the request: send the ${BASE_URL_HEADER} ` +
-          'header. Refusing rather than falling back to a fixed TOOLJET_URL.'
-      );
-    }
 
     if (identity.pat) return { apiUrl, appUrl, pat: identity.pat };
     return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,34 @@ function readHeader(headers: HeaderBag, name: string): string | undefined {
 }
 
 /**
+ * Validate the request-supplied target origin, or throw.
+ *
+ * Gets the caller's session/PAT attached and sent straight to it (auth.ts), so this closes the
+ * parse+scheme gap (garbage input, http downgrade) — not a host allowlist, still trusts any https host.
+ */
+function validateApiUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${BASE_URL_HEADER} must be a valid absolute URL.`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${BASE_URL_HEADER} must use https.`);
+  }
+  if (
+    (parsed.pathname !== '' && parsed.pathname !== '/') ||
+    parsed.search ||
+    parsed.hash ||
+    parsed.username ||
+    parsed.password
+  ) {
+    throw new Error(`${BASE_URL_HEADER} must be a bare origin (scheme + host only, no path/query/credentials).`);
+  }
+  return parsed.origin;
+}
+
+/**
  * Extract the acting user from request headers, or undefined when the caller sent none.
  *
  * A session WITHOUT a workspace throws rather than returning undefined. Returning undefined would
@@ -79,7 +107,8 @@ export function identityFromHeaders(
   const sessionToken = readHeader(headers, SESSION_TOKEN_HEADER);
   const workspaceId = readHeader(headers, WORKSPACE_ID_HEADER);
   const pat = readHeader(headers, PAT_HEADER);
-  const apiUrl = readHeader(headers, BASE_URL_HEADER);
+  const rawApiUrl = readHeader(headers, BASE_URL_HEADER);
+  const apiUrl = rawApiUrl ? validateApiUrl(rawApiUrl) : undefined;
 
   if (pat) {
     /* A PAT names whoever owns it and lives for weeks; a session names the person this request is

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,10 +194,9 @@ export function loadConfig(identity?: RequestIdentity): Config {
   const staticApiUrl = explicitApiUrl ?? 'http://localhost:3000';
   // TOOLJET_APP_URL is the old name — "app" read as "one ToolJet app" more often than "the ToolJet
   // deployment", which is what this actually is. TOOLJET_DEPLOYMENT_URL is preferred; the old name
-  // keeps working so nobody's existing config breaks. Falls back to TOOLJET_URL (only when that was
-  // actually set, not its own localhost default) rather than requiring a second URL for the common
-  // case where the same origin serves both — a self-hosted instance behind one reverse proxy.
-  const appUrl = env('TOOLJET_DEPLOYMENT_URL') ?? env('TOOLJET_APP_URL') ?? explicitApiUrl ?? 'http://localhost:8082';
+  // keeps working so nobody's existing config breaks. An explicit value here always wins — it is a
+  // deliberate override, not a guess — falling through only when the operator hasn't set one.
+  const explicitAppUrl = env('TOOLJET_DEPLOYMENT_URL') ?? env('TOOLJET_APP_URL');
 
   if (identity) {
     // The request's own apiUrl wins when present — same precedence as the session/PAT identity
@@ -209,6 +208,11 @@ export function loadConfig(identity?: RequestIdentity): Config {
     // that simply sent no headers (identity also arrives as undefined) — only the HTTP layer that
     // built `identity` from a real request knows which case it is.
     const apiUrl = identity.apiUrl ?? staticApiUrl;
+    // appUrl must follow the SAME per-request target apiUrl just resolved above, not the server's own
+    // static config: a shared server acting for many different ToolJet backends has no single static
+    // app URL that could ever be right for all of them. Most self-hosted instances serve the API and
+    // the UI from the same origin, so the request's own apiUrl is the right default here too.
+    const appUrl = explicitAppUrl ?? identity.apiUrl ?? staticApiUrl;
 
     if (identity.pat) return { apiUrl, appUrl, pat: identity.pat };
     return {
@@ -221,6 +225,7 @@ export function loadConfig(identity?: RequestIdentity): Config {
   }
 
   const apiUrl = staticApiUrl;
+  const appUrl = explicitAppUrl ?? explicitApiUrl ?? 'http://localhost:8082';
 
   const pat = env('TOOLJET_PAT');
   const sessionToken = env('TOOLJET_SESSION_TOKEN');

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,13 +57,29 @@ function env(name: string): string | undefined {
   return value ? value : undefined;
 }
 
-function allowedApiOrigins(): string[] {
+/**
+ * MCP_ALLOWED_API_ORIGINS, normalized to the same form `new URL(...).origin` produces for a request's
+ * x-tooljet-url — lowercased, default port stripped, no trailing slash. Comparing raw config strings
+ * against a normalized origin means "https://Foo.com" or "https://foo.com:443" in the env var would
+ * never match a request that is, in every way that matters, the same host — denying real traffic while
+ * looking, to whoever reads the config next to the error, like it should have matched. Throws rather
+ * than silently keeping an entry nothing can ever match: a misconfigured allowlist should fail loudly
+ * where an operator is looking (startup), not blend into "not in the allowlist" for the first caller.
+ */
+export function allowedApiOrigins(): string[] {
   const raw = env(ALLOWED_API_ORIGINS_VAR);
   if (!raw) return [];
   return raw
     .split(',')
     .map((entry) => entry.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .map((entry) => {
+      try {
+        return new URL(entry).origin;
+      } catch {
+        throw new Error(`${ALLOWED_API_ORIGINS_VAR} contains an entry that is not a valid URL: "${entry}".`);
+      }
+    });
 }
 
 type HeaderBag = Record<string, string | string[] | undefined>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { createServer, type Server } from 'node:http';
+import { pathToFileURL } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -197,7 +198,14 @@ async function main(): Promise<void> {
 // createGatewayHttpServer is exported for tests to spin up a real server on an ephemeral port; without
 // this guard, importing it for that export would also fire main() as a side effect, which in stdio
 // mode tries to connect a real StdioServerTransport (reading process.stdin) inside the test process.
-if (import.meta.url === `file://${process.argv[1]}`) {
+//
+// A plain `file://${process.argv[1]}` string compare is NOT equivalent to import.meta.url: the latter
+// percent-encodes spaces/`#`/`?`/non-ASCII and always uses forward slashes, while argv[1] is the raw
+// OS path — so a space in the path (a macOS account name, a "Program Files"-style directory) or
+// Windows entirely (backslashes, a bare drive letter) would never match, silently skipping main()
+// with no error, no output, exit 0. pathToFileURL applies the exact same escaping Node used to build
+// import.meta.url, so the comparison holds on both platforms.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createServer } from 'node:http';
+import { createServer, type Server } from 'node:http';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -15,18 +15,20 @@ import {
   type RequestIdentity,
 } from './config.js';
 
-async function serveHttp(): Promise<void> {
-  const port = Number(process.env.PORT ?? 8787);
-  const sharedToken = process.env.MCP_SHARED_TOKEN;
+export interface GatewayHttpServer {
+  server: Server;
+  /** Whether this instance came up in gateway mode (MCP_SHARED_TOKEN set) or direct mode. */
+  gatewayMode: boolean;
+}
 
-  // Fail at startup, not on the first request that happens to hit a bad entry: a misconfigured
-  // MCP_ALLOWED_API_ORIGINS should surface where an operator is looking, right after they set it.
-  try {
-    allowedApiOrigins();
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
-  }
+/**
+ * Build the gateway/direct-mode HTTP server (all request-handling logic), without binding a port.
+ * Split out from serveHttp so tests can start it on an ephemeral port and exercise the real gates —
+ * bearer auth, the user-session requirement, the request-URL requirement — with real HTTP requests,
+ * the same way httpServer.ts's createHttpMcpServer is tested.
+ */
+export function createGatewayHttpServer(): GatewayHttpServer {
+  const sharedToken = process.env.MCP_SHARED_TOKEN;
 
   /* Two deployment shapes, told apart by whether a shared token is configured.
 
@@ -39,7 +41,6 @@ async function serveHttp(): Promise<void> {
      both the proof and the identity, and ToolJet validates it on every call. Binds loopback by
      default precisely because that token now travels over the wire. */
   const gatewayMode = Boolean(sharedToken);
-  const host = process.env.MCP_HTTP_HOST ?? (gatewayMode ? '0.0.0.0' : '127.0.0.1');
 
   /* Gateway mode serves EVERY user, so the acting user must arrive per request. Require it
      explicitly when asked: a deployment that also has a PAT configured would otherwise fall back to
@@ -145,6 +146,24 @@ async function serveHttp(): Promise<void> {
       });
   });
 
+  return { server: httpServer, gatewayMode };
+}
+
+async function serveHttp(): Promise<void> {
+  const port = Number(process.env.PORT ?? 8787);
+
+  // Fail at startup, not on the first request that happens to hit a bad entry: a misconfigured
+  // MCP_ALLOWED_API_ORIGINS should surface where an operator is looking, right after they set it.
+  try {
+    allowedApiOrigins();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
+  }
+
+  const { server: httpServer, gatewayMode } = createGatewayHttpServer();
+  const host = process.env.MCP_HTTP_HOST ?? (gatewayMode ? '0.0.0.0' : '127.0.0.1');
+
   await new Promise<void>((resolve, reject) => {
     httpServer.once('error', reject);
     httpServer.listen(port, host, resolve);
@@ -174,7 +193,13 @@ async function main(): Promise<void> {
   await server.connect(new StdioServerTransport());
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run as the actual CLI entrypoint (`node bundle/index.js` or similar) — NOT on import.
+// createGatewayHttpServer is exported for tests to spin up a real server on an ephemeral port; without
+// this guard, importing it for that export would also fire main() as a side effect, which in stdio
+// mode tries to connect a real StdioServerTransport (reading process.stdin) inside the test process.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,13 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { buildServer, buildUnconfiguredServer } from './server.js';
 import { bearerValue, checkBearerToken } from './httpAuth.js';
-import { identityFromHeaders, PAT_HEADER, SESSION_TOKEN_HEADER, type RequestIdentity } from './config.js';
+import {
+  BASE_URL_HEADER,
+  identityFromHeaders,
+  PAT_HEADER,
+  SESSION_TOKEN_HEADER,
+  type RequestIdentity,
+} from './config.js';
 
 async function serveHttp(): Promise<void> {
   const port = Number(process.env.PORT ?? 8787);
@@ -35,6 +41,11 @@ async function serveHttp(): Promise<void> {
     (/^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_USER_SESSION ?? '') ||
       !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN));
 
+  /* Same idea, for the target backend rather than the acting user: gateway mode can serve many
+     different ToolJet backends, so a deployment can demand every request name its own via
+     x-tooljet-url rather than silently writing into this process's static TOOLJET_URL. */
+  const requireRequestUrl = gatewayMode && /^(1|true|yes|on)$/i.test(process.env.MCP_REQUIRE_REQUEST_URL ?? '');
+
   const httpServer = createServer((req, res) => {
     // The bearer token authenticates the CALLER (that it is the trusted AI shim). The identity
     // headers below say which user it is acting for. Checked first: an unauthenticated caller must
@@ -62,7 +73,13 @@ async function serveHttp(): Promise<void> {
       if (bearer) identity = { pat: bearer };
     }
 
-    if (!identity && requireUserSession) {
+    // Whether this request actually named an acting user — NOT whether `identity` is merely
+    // truthy. A request that sent only x-tooljet-url (no session, no PAT) produces a truthy
+    // `identity` too, and treating that as "a user was named" would let it walk straight past the
+    // check below with nobody actually signed in.
+    const hasUserCredential = Boolean(identity?.pat || identity?.sessionToken);
+
+    if (!hasUserCredential && requireUserSession) {
       res
         .writeHead(400, { 'Content-Type': 'text/plain' })
         .end(
@@ -72,9 +89,19 @@ async function serveHttp(): Promise<void> {
       return;
     }
 
+    if (!identity?.apiUrl && requireRequestUrl) {
+      res
+        .writeHead(400, { 'Content-Type': 'text/plain' })
+        .end(
+          `This server acts only on the backend named in the request: send the ${BASE_URL_HEADER} ` +
+            'header. Refusing rather than falling back to a fixed TOOLJET_URL.'
+        );
+      return;
+    }
+
     // Direct mode with nothing to act as: no PAT on the request and none in the environment. Say so
     // in the response rather than letting buildServer throw into a bare 500.
-    if (!gatewayMode && !identity && !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN)) {
+    if (!gatewayMode && !hasUserCredential && !(process.env.TOOLJET_PAT || process.env.TOOLJET_SESSION_TOKEN)) {
       res
         .writeHead(401, { 'Content-Type': 'text/plain' })
         .end(

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { buildServer, buildUnconfiguredServer } from './server.js';
 import { bearerValue, checkBearerToken } from './httpAuth.js';
 import {
+  allowedApiOrigins,
+  ALLOWED_API_ORIGINS_VAR,
   BASE_URL_HEADER,
   identityFromHeaders,
   PAT_HEADER,
@@ -16,6 +18,15 @@ import {
 async function serveHttp(): Promise<void> {
   const port = Number(process.env.PORT ?? 8787);
   const sharedToken = process.env.MCP_SHARED_TOKEN;
+
+  // Fail at startup, not on the first request that happens to hit a bad entry: a misconfigured
+  // MCP_ALLOWED_API_ORIGINS should surface where an operator is looking, right after they set it.
+  try {
+    allowedApiOrigins();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`tooljet-mcp: invalid ${ALLOWED_API_ORIGINS_VAR}: ${reason}`);
+  }
 
   /* Two deployment shapes, told apart by whether a shared token is configured.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createServer, type Server } from 'node:http';
-import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -194,18 +195,25 @@ async function main(): Promise<void> {
   await server.connect(new StdioServerTransport());
 }
 
-// Only run as the actual CLI entrypoint (`node bundle/index.js` or similar) — NOT on import.
-// createGatewayHttpServer is exported for tests to spin up a real server on an ephemeral port; without
-// this guard, importing it for that export would also fire main() as a side effect, which in stdio
-// mode tries to connect a real StdioServerTransport (reading process.stdin) inside the test process.
-//
-// A plain `file://${process.argv[1]}` string compare is NOT equivalent to import.meta.url: the latter
-// percent-encodes spaces/`#`/`?`/non-ASCII and always uses forward slashes, while argv[1] is the raw
-// OS path — so a space in the path (a macOS account name, a "Program Files"-style directory) or
-// Windows entirely (backslashes, a bare drive letter) would never match, silently skipping main()
-// with no error, no output, exit 0. pathToFileURL applies the exact same escaping Node used to build
-// import.meta.url, so the comparison holds on both platforms.
-if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+/**
+ * Whether this module is the actual CLI entrypoint, not merely imported (tests import
+ * createGatewayHttpServer, which would otherwise fire main() as a side effect). A raw string compare
+ * against import.meta.url breaks on a path with a space (different escaping) or a symlinked launch
+ * dir (import.meta.url resolves through it, argv[1] doesn't) — realpathSync on both sides avoids both.
+ */
+function isEntrypoint(): boolean {
+  const invoked = process.argv[1];
+  if (!invoked) return false;
+  try {
+    return realpathSync(invoked) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    // argv[1] doesn't resolve to a real file (invoked via -e, a REPL, or something unusual) — not
+    // "run me directly" in the sense this guard cares about.
+    return false;
+  }
+}
+
+if (isEntrypoint()) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -164,39 +164,46 @@ describe('gateway servers refuse a PAT as identity', () => {
 describe('per-request target origin (x-tooljet-url)', () => {
   beforeEach(() => {
     delete process.env.TOOLJET_URL;
+    delete process.env.MCP_ALLOWED_API_ORIGINS;
   });
 
-  it('accepts a bare https origin', () => {
+  it('accepts an allowlisted bare https origin', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toEqual({
       apiUrl: 'https://tj.example.com',
     });
   });
 
   /* ToolJet supports SUB_PATH hosting, so a self-hosted customer reverse-proxied under a path
-     prefix is a legitimate target, not a malformed one. */
+     prefix is a legitimate target, not a malformed one. The allowlist names the host, not the path. */
   it('accepts a path prefix, for SUB_PATH-hosted self-hosted instances', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/tooljet' })).toEqual({
       apiUrl: 'https://tj.example.com/tooljet',
     });
   });
 
   it('normalizes away a trailing slash rather than treating it as a different target', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/tooljet/' })).toEqual({
       apiUrl: 'https://tj.example.com/tooljet',
     });
   });
 
   it('rejects plain http, which would send the session cookie or PAT in plaintext', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(() => identityFromHeaders({ 'x-tooljet-url': 'http://tj.example.com' })).toThrow(/must use https/);
   });
 
   it('rejects a query string', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/?x=1' })).toThrow(
       /query, hash, or credentials/
     );
   });
 
   it('rejects embedded credentials', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
     expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://user:pass@tj.example.com' })).toThrow(
       /query, hash, or credentials/
     );
@@ -204,6 +211,29 @@ describe('per-request target origin (x-tooljet-url)', () => {
 
   it('rejects a value that does not parse as an absolute URL', () => {
     expect(() => identityFromHeaders({ 'x-tooljet-url': 'not a url' })).toThrow(/valid absolute URL/);
+  });
+
+  /* https alone does not make a host trustworthy — an attacker's own domain has a valid cert too.
+     Sending the session cookie or PAT there regardless of the allowlist is the exact exfiltration
+     path this check exists to close. */
+  it('rejects an origin not in MCP_ALLOWED_API_ORIGINS, even a well-formed https one', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://evil.example' })).toThrow(
+      /not in MCP_ALLOWED_API_ORIGINS/
+    );
+  });
+
+  it('rejects every https origin when the allowlist is unset — unset means empty, not "allow anything"', () => {
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toThrow(
+      /not in MCP_ALLOWED_API_ORIGINS/
+    );
+  });
+
+  it('accepts any origin named in a multi-entry, whitespace-tolerant allowlist', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = ' https://a.example.com , https://b.example.com ';
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://b.example.com' })).toEqual({
+      apiUrl: 'https://b.example.com',
+    });
   });
 
   it('wins over a configured static TOOLJET_URL', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -89,6 +89,29 @@ describe('appUrl defaults to the deployment origin', () => {
     process.env.TOOLJET_PAT = 'tj_pat_test';
     expect(loadConfig().appUrl).toBe('https://new.example.com');
   });
+
+  /* A shared server acting for many different ToolJet backends has no single static app URL that
+     could ever be right for all of them — its own TOOLJET_URL is just wherever ITS operator's config
+     happens to point, unrelated to whoever the request is actually acting for. */
+  it('follows the per-request apiUrl, not the server\'s own static TOOLJET_URL', () => {
+    process.env.TOOLJET_URL = 'https://operators-own-instance.example.com';
+    const c = loadConfig({
+      sessionToken: 'SESSION',
+      workspaceId: 'org-1',
+      apiUrl: 'https://caller.example.com',
+    });
+    expect(c.appUrl).toBe('https://caller.example.com');
+  });
+
+  it('still lets an explicit TOOLJET_DEPLOYMENT_URL override the per-request apiUrl', () => {
+    process.env.TOOLJET_DEPLOYMENT_URL = 'https://deliberately-different.example.com';
+    const c = loadConfig({
+      sessionToken: 'SESSION',
+      workspaceId: 'org-1',
+      apiUrl: 'https://caller.example.com',
+    });
+    expect(c.appUrl).toBe('https://deliberately-different.example.com');
+  });
 });
 
 /* Staging and cloud run one shared MCP for every user, so identity arrives per request instead of

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -158,6 +158,67 @@ describe('gateway servers refuse a PAT as identity', () => {
   });
 });
 
+/* One shared MCP server can act on many different ToolJet backends, so the request itself may name
+   its target. That header gets the caller's session/PAT attached and sent straight to it (auth.ts),
+   so it needs real validation, not just a truthy string. */
+describe('per-request target origin (x-tooljet-url)', () => {
+  beforeEach(() => {
+    delete process.env.TOOLJET_URL;
+  });
+
+  it('accepts a bare https origin', () => {
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toEqual({
+      apiUrl: 'https://tj.example.com',
+    });
+  });
+
+  /* ToolJet supports SUB_PATH hosting, so a self-hosted customer reverse-proxied under a path
+     prefix is a legitimate target, not a malformed one. */
+  it('accepts a path prefix, for SUB_PATH-hosted self-hosted instances', () => {
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/tooljet' })).toEqual({
+      apiUrl: 'https://tj.example.com/tooljet',
+    });
+  });
+
+  it('normalizes away a trailing slash rather than treating it as a different target', () => {
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/tooljet/' })).toEqual({
+      apiUrl: 'https://tj.example.com/tooljet',
+    });
+  });
+
+  it('rejects plain http, which would send the session cookie or PAT in plaintext', () => {
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'http://tj.example.com' })).toThrow(/must use https/);
+  });
+
+  it('rejects a query string', () => {
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com/?x=1' })).toThrow(
+      /query, hash, or credentials/
+    );
+  });
+
+  it('rejects embedded credentials', () => {
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://user:pass@tj.example.com' })).toThrow(
+      /query, hash, or credentials/
+    );
+  });
+
+  it('rejects a value that does not parse as an absolute URL', () => {
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'not a url' })).toThrow(/valid absolute URL/);
+  });
+
+  it('wins over a configured static TOOLJET_URL', () => {
+    process.env.TOOLJET_URL = 'https://static.example.com';
+    const c = loadConfig({ sessionToken: 'SESSION', workspaceId: 'org-1', apiUrl: 'https://request.example.com' });
+    expect(c.apiUrl).toBe('https://request.example.com');
+  });
+
+  it('falls back to the static TOOLJET_URL when the request named none', () => {
+    process.env.TOOLJET_URL = 'https://static.example.com';
+    const c = loadConfig({ sessionToken: 'SESSION', workspaceId: 'org-1' });
+    expect(c.apiUrl).toBe('https://static.example.com');
+  });
+});
+
 describe('blank environment variables count as unset', () => {
   beforeEach(() => {
     for (const k of ['TOOLJET_URL', 'TOOLJET_APP_URL', 'TOOLJET_PAT', 'TOOLJET_SESSION_TOKEN', 'TOOLJET_WORKSPACE_ID'])

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -6,6 +6,7 @@ describe('loadConfig', () => {
     for (const k of [
       'TOOLJET_URL',
       'TOOLJET_APP_URL',
+      'TOOLJET_DEPLOYMENT_URL',
       'TOOLJET_PAT',
       'TOOLJET_SESSION_TOKEN',
       'TOOLJET_WORKSPACE_ID',
@@ -44,6 +45,49 @@ describe('loadConfig', () => {
   it('refuses a session with no workspace rather than guessing one', () => {
     process.env.TOOLJET_SESSION_TOKEN = 'SESSION';
     expect(() => loadConfig()).toThrow(/TOOLJET_WORKSPACE_ID is required/);
+  });
+});
+
+/* Most self-hosted instances serve the API and the UI from the same origin, so requiring a second
+   URL for something used only to build a few cosmetic links is friction most deployments don't need. */
+describe('appUrl defaults to the deployment origin', () => {
+  beforeEach(() => {
+    for (const k of [
+      'TOOLJET_URL',
+      'TOOLJET_APP_URL',
+      'TOOLJET_DEPLOYMENT_URL',
+      'TOOLJET_PAT',
+      'TOOLJET_SESSION_TOKEN',
+      'TOOLJET_WORKSPACE_ID',
+    ])
+      delete process.env[k];
+  });
+
+  it('falls back to TOOLJET_URL when neither app-URL variable is set', () => {
+    process.env.TOOLJET_URL = 'https://tj.example.com';
+    process.env.TOOLJET_PAT = 'tj_pat_test';
+    expect(loadConfig().appUrl).toBe('https://tj.example.com');
+  });
+
+  it('still defaults to localhost:8082 when TOOLJET_URL itself is unset', () => {
+    process.env.TOOLJET_PAT = 'tj_pat_test';
+    expect(loadConfig().appUrl).toBe('http://localhost:8082');
+  });
+
+  /* TOOLJET_APP_URL is the old name, kept working so nobody's existing config breaks. */
+  it('prefers an explicit TOOLJET_APP_URL over the TOOLJET_URL fallback', () => {
+    process.env.TOOLJET_URL = 'https://tj.example.com';
+    process.env.TOOLJET_APP_URL = 'https://app.tj.example.com';
+    process.env.TOOLJET_PAT = 'tj_pat_test';
+    expect(loadConfig().appUrl).toBe('https://app.tj.example.com');
+  });
+
+  it('prefers TOOLJET_DEPLOYMENT_URL, the new name, over both TOOLJET_APP_URL and TOOLJET_URL', () => {
+    process.env.TOOLJET_URL = 'https://tj.example.com';
+    process.env.TOOLJET_APP_URL = 'https://old.example.com';
+    process.env.TOOLJET_DEPLOYMENT_URL = 'https://new.example.com';
+    process.env.TOOLJET_PAT = 'tj_pat_test';
+    expect(loadConfig().appUrl).toBe('https://new.example.com');
   });
 });
 
@@ -283,7 +327,14 @@ describe('per-request target origin (x-tooljet-url)', () => {
 
 describe('blank environment variables count as unset', () => {
   beforeEach(() => {
-    for (const k of ['TOOLJET_URL', 'TOOLJET_APP_URL', 'TOOLJET_PAT', 'TOOLJET_SESSION_TOKEN', 'TOOLJET_WORKSPACE_ID'])
+    for (const k of [
+      'TOOLJET_URL',
+      'TOOLJET_APP_URL',
+      'TOOLJET_DEPLOYMENT_URL',
+      'TOOLJET_PAT',
+      'TOOLJET_SESSION_TOKEN',
+      'TOOLJET_WORKSPACE_ID',
+    ])
       delete process.env[k];
   });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -236,6 +236,38 @@ describe('per-request target origin (x-tooljet-url)', () => {
     });
   });
 
+  /* A raw string comparison would never match here: the request's origin is always in the form
+     new URL(...).origin produces (lowercased, default port stripped, no trailing slash), so an
+     allowlist entry written any other way has to be normalized the same way or it can never match —
+     denying real traffic while looking, next to the error, like it should have worked. */
+  it('normalizes an allowlist entry with different casing to the same origin', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://Tj.Example.com';
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toEqual({
+      apiUrl: 'https://tj.example.com',
+    });
+  });
+
+  it('normalizes an allowlist entry with a trailing slash', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com/';
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toEqual({
+      apiUrl: 'https://tj.example.com',
+    });
+  });
+
+  it('normalizes an allowlist entry carrying the default https port', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com:443';
+    expect(identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toEqual({
+      apiUrl: 'https://tj.example.com',
+    });
+  });
+
+  it('throws, naming the bad entry, when MCP_ALLOWED_API_ORIGINS has an unparseable value', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com, not a url';
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toThrow(
+      /not a valid URL: "not a url"/
+    );
+  });
+
   it('wins over a configured static TOOLJET_URL', () => {
     process.env.TOOLJET_URL = 'https://static.example.com';
     const c = loadConfig({ sessionToken: 'SESSION', workspaceId: 'org-1', apiUrl: 'https://request.example.com' });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -112,6 +112,16 @@ describe('appUrl defaults to the deployment origin', () => {
     });
     expect(c.appUrl).toBe('https://deliberately-different.example.com');
   });
+
+  /* Local dev with an identity but no request-named apiUrl and nothing configured: appUrl must land
+     on the UI's own dev default (8082), the same as the no-identity/stdio branch below — not on
+     apiUrl's internal 3000 default, which the identity branch would silently inherit via staticApiUrl
+     if it fell through to that instead of explicitApiUrl. */
+  it('falls back to localhost:8082, not apiUrl\'s own 3000 default, when nothing at all is configured', () => {
+    const c = loadConfig({ sessionToken: 'SESSION', workspaceId: 'org-1' });
+    expect(c.apiUrl).toBe('http://localhost:3000');
+    expect(c.appUrl).toBe('http://localhost:8082');
+  });
 });
 
 /* Staging and cloud run one shared MCP for every user, so identity arrives per request instead of

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -335,6 +335,17 @@ describe('per-request target origin (x-tooljet-url)', () => {
     );
   });
 
+  /* A request's own origin must already be https before it ever reaches the allowlist check
+     (validateApiUrl), so a non-https allowlist entry — a typo'd "http://" — could never match
+     anything. Silently keeping it would leave the operator with a dead entry and no signal it's
+     wrong, the same shape of failure as the un-normalized entries this file already guards against. */
+  it('throws, naming the bad entry, when MCP_ALLOWED_API_ORIGINS has a non-https entry', () => {
+    process.env.MCP_ALLOWED_API_ORIGINS = 'http://tj.example.com';
+    expect(() => identityFromHeaders({ 'x-tooljet-url': 'https://tj.example.com' })).toThrow(
+      /"http:\/\/tj\.example\.com" must use https/
+    );
+  });
+
   it('wins over a configured static TOOLJET_URL', () => {
     process.env.TOOLJET_URL = 'https://static.example.com';
     const c = loadConfig({ sessionToken: 'SESSION', workspaceId: 'org-1', apiUrl: 'https://request.example.com' });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Server } from 'node:http';
+import { createGatewayHttpServer } from '../src/index.js';
+
+/* The two fixes below were flagged in review as untested and would regress silently: identity-object
+   truthiness standing in for "a user was named" (index.ts's requireUserSession gate), and
+   MCP_REQUIRE_REQUEST_URL living somewhere unreachable. Both are pre-handshake, early-return checks
+   in the raw request handler, so plain fetch() is enough — no need for a full MCP client/handshake. */
+
+const ENV_KEYS = [
+  'MCP_SHARED_TOKEN',
+  'MCP_REQUIRE_USER_SESSION',
+  'MCP_REQUIRE_REQUEST_URL',
+  'MCP_ALLOWED_API_ORIGINS',
+  'TOOLJET_PAT',
+  'TOOLJET_SESSION_TOKEN',
+];
+
+const runningServers: Server[] = [];
+
+async function listen(server: Server): Promise<URL> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected an IP listener');
+  return new URL(`http://127.0.0.1:${address.port}`);
+}
+
+function initializeBody() {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'index-test-client', version: '1.0.0' },
+    },
+  });
+}
+
+const jsonHeaders = { accept: 'application/json, text/event-stream', 'content-type': 'application/json' };
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(async () => {
+  await Promise.allSettled(runningServers.splice(0).map((server) => new Promise((r) => server.close(r))));
+});
+
+describe('createGatewayHttpServer — mode selection', () => {
+  it('reports gateway mode when MCP_SHARED_TOKEN is set', () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    expect(createGatewayHttpServer().gatewayMode).toBe(true);
+  });
+
+  it('reports direct mode when MCP_SHARED_TOKEN is unset', () => {
+    expect(createGatewayHttpServer().gatewayMode).toBe(false);
+  });
+});
+
+describe('gateway mode — bearer gate', () => {
+  it('rejects a request with no bearer token', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), { method: 'POST', headers: jsonHeaders, body: initializeBody() });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a request with the wrong bearer token', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: { ...jsonHeaders, authorization: 'Bearer wrong-token' },
+      body: initializeBody(),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+/* The actual bypass: a request carrying ONLY x-tooljet-url (no session, no PAT) used to produce a
+   truthy `identity` object (it has an apiUrl field), which satisfied `!identity` and walked straight
+   past the "must act on behalf of a signed-in user" check with nobody actually signed in. */
+describe('gateway mode — requireUserSession is not satisfied by an apiUrl-only identity', () => {
+  it('refuses a request with only x-tooljet-url and no session, same as a request with nothing at all', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    process.env.MCP_ALLOWED_API_ORIGINS = 'https://tj.example.com';
+    // No TOOLJET_PAT/TOOLJET_SESSION_TOKEN on the server, so requireUserSession is implicitly on.
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: {
+        ...jsonHeaders,
+        authorization: 'Bearer shared-secret',
+        'x-tooljet-url': 'https://tj.example.com',
+      },
+      body: initializeBody(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/acts only on behalf of a signed-in user/);
+  });
+
+  it('still refuses a bare request with no identity headers at all', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: { ...jsonHeaders, authorization: 'Bearer shared-secret' },
+      body: initializeBody(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/acts only on behalf of a signed-in user/);
+  });
+
+  it('accepts a real session, which is what the gate is meant to require', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: {
+        ...jsonHeaders,
+        authorization: 'Bearer shared-secret',
+        'x-tooljet-session': 'SESSION',
+        'x-tooljet-workspace-id': 'org-1',
+      },
+      body: initializeBody(),
+    });
+
+    // Clears both the session gate and the request-URL gate (unset, so not required); whatever
+    // happens next is the MCP handshake's concern, not this gate's.
+    expect(res.status).not.toBe(400);
+    expect(res.status).not.toBe(401);
+  });
+});
+
+/* The other bypass: MCP_REQUIRE_REQUEST_URL used to live inside loadConfig's `if (identity)` branch,
+   which a fully headerless request never reaches (identity arrives as undefined either way) — so the
+   flag could never actually fire for the one case it exists to catch. */
+describe('gateway mode — MCP_REQUIRE_REQUEST_URL is reachable', () => {
+  it('refuses a request with a valid session but no x-tooljet-url when the flag is set', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    process.env.MCP_REQUIRE_REQUEST_URL = 'true';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: {
+        ...jsonHeaders,
+        authorization: 'Bearer shared-secret',
+        'x-tooljet-session': 'SESSION',
+        'x-tooljet-workspace-id': 'org-1',
+      },
+      body: initializeBody(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/backend named in the request/);
+  });
+
+  it('does not require it when the flag is unset', async () => {
+    process.env.MCP_SHARED_TOKEN = 'shared-secret';
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: {
+        ...jsonHeaders,
+        authorization: 'Bearer shared-secret',
+        'x-tooljet-session': 'SESSION',
+        'x-tooljet-workspace-id': 'org-1',
+      },
+      body: initializeBody(),
+    });
+
+    expect(res.status).not.toBe(400);
+  });
+});
+
+describe('direct mode', () => {
+  it('refuses a request with no credential anywhere', async () => {
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), { method: 'POST', headers: jsonHeaders, body: initializeBody() });
+    expect(res.status).toBe(401);
+    expect(await res.text()).toMatch(/No ToolJet credential/);
+  });
+
+  it('accepts a PAT sent as a bearer token', async () => {
+    const { server } = createGatewayHttpServer();
+    runningServers.push(server);
+    const baseUrl = await listen(server);
+
+    const res = await fetch(new URL('/', baseUrl), {
+      method: 'POST',
+      headers: { ...jsonHeaders, authorization: 'Bearer tj_pat_caller' },
+      body: initializeBody(),
+    });
+
+    expect(res.status).not.toBe(401);
+  });
+});


### PR DESCRIPTION
## 📝 What this does

`tooljet-mcp` picks its target ToolJet backend from one static `TOOLJET_URL` env var per process. That's correct for a server one operator owns, but staging/cloud run ONE shared `tooljet-mcp` behind the gateway serving many different ToolJet backends — self-hosted-credits customers on their own domains, plus ToolJet Cloud itself. A fixed `TOOLJET_URL` can only ever be right for one of them; every other caller's build silently lands in the wrong backend.

This lets the request name its own target. A new `x-tooljet-url` header carries the calling ToolJet instance's own API origin, same as the session/workspace headers already do for identity. When present, and when its origin is on the configured allowlist, it wins over the static `TOOLJET_URL`. When absent, behavior is unchanged — static `TOOLJET_URL` still applies, so stdio/local/direct-mode servers (a dev's own laptop) need no changes at all.

A companion flag, `MCP_REQUIRE_REQUEST_URL`, lets a shared deployment refuse to fall back to the static value at all — loud error instead of a silent wrong-backend write.

**Review feedback addressed (@Navaneeth):**
- Host allowlist added (`MCP_ALLOWED_API_ORIGINS`), fails closed — was the actual blocker.
- `x-tooljet-url`-only requests no longer bypass the "must act on behalf of a signed-in user" gate.
- `MCP_REQUIRE_REQUEST_URL` moved to where it's actually reachable (was dead for a headerless request).
- SUB_PATH self-hosted deployments (a path prefix) are accepted, not rejected as malformed.
- Test coverage added for the validator (was zero).
- `MCP_ALLOWED_API_ORIGINS` entries are now normalized through `new URL(entry).origin` (was comparing raw config strings against a normalized origin — `https://Foo.com`, a trailing slash, or an explicit `:443` could never match). Checked once at HTTP server startup, not lazily on the first matching request.

**Also this round — `TOOLJET_APP_URL` renamed (@Navaneeth):** the name read as "URL of one app" more often than "the ToolJet deployment," and most self-hosted customers run one origin for both frontend and backend anyway. Renamed to `TOOLJET_DEPLOYMENT_URL`; falls back to `TOOLJET_URL` when unset, so one var covers the common case. Old name still honored in `config.ts` (Docker Compose, systemd, anything setting env vars directly), dropped from the plugin manifests since that's the visible surface causing the confusion.

**Caught by @Navaneeth, re-verified against the code — a real regression from the rename above:** `appUrl` was computed once from static env only and reused unchanged even inside the `if (identity)` branch, where `apiUrl` was already correctly resolving per-request. On a shared server acting for many different ToolJet backends, that meant every caller's cosmetic links (datasource settings, app editor/viewer URLs) silently resolved against the *operator's own* static config instead of the actual calling instance — breaking exactly the deployment this PR is for. Fixed: `appUrl` now follows the request's own `apiUrl` by default in that branch (same same-origin assumption as the `TOOLJET_URL` fallback); an explicit `TOOLJET_DEPLOYMENT_URL`/`TOOLJET_APP_URL` still overrides it when genuinely set.

**One remaining gap flagged by @Navaneeth — `index.ts` itself had zero tests:** it holds the fixes for both bypasses raised in review (`hasUserCredential`, the `requireRequestUrl` refusal) plus the new startup allowlist check, none of it exercised by a real request. Split `createGatewayHttpServer` out of `serveHttp` — same shape as `httpServer.ts`'s `createHttpMcpServer` — so tests can start it on an ephemeral port and hit it with real HTTP. That surfaced a real side effect along the way: `index.ts`'s top-level `main().catch(...)` ran unconditionally on module load, so importing the new export for tests also fired it — attempting `buildServer()` with no credential configured and trying to connect a live `StdioServerTransport` inside the test process. Guarded it to run only as the actual CLI entrypoint; verified both directions (still starts correctly via `node bundle/index.js`, no longer fires on import).

**Blocker, caught by @Navaneeth — that entrypoint guard itself was broken.** The first version compared `import.meta.url === \`file://${process.argv[1]}\`` directly. That's not equivalent: `import.meta.url` percent-encodes spaces/`#`/`?`/non-ASCII and always uses forward slashes, while `argv[1]` is the raw OS path. Any path with a space (a macOS account name, a "Program Files"-style directory) or Windows entirely (backslashes, a bare drive letter) would never match — `main()` silently never runs, the process exits 0, nothing is printed. Since `mcp.json`/`plugin.json` launch via `${PLUGIN_ROOT}/bundle/index.js`, every affected user would get a server that comes up and does nothing, with no error to debug from. Fixed with `pathToFileURL(process.argv[1])`, which applies the exact escaping Node used to build `import.meta.url` — the documented pattern for this check. Verified directly: a probe script in a path containing a space now reports a match (was a mismatch before); rebuilt the bundle and ran the actual packaged CLI from a space-containing path — starts and logs correctly. Not unit-testable (`import.meta.url` is fixed to whatever file executes it), so verified as a real subprocess instead.

**Found by testing further, same class as the above:** `pathToFileURL` alone fixed the encoding mismatch but missed a second one — Node's ESM loader resolves `import.meta.url` through symlinks, while `argv[1]` is whatever path the launcher used verbatim. A symlinked plugin cache/marketplace directory would still mismatch. `realpathSync` on both sides closes both gaps at once. Verified all three failure modes directly (normal path, space in path, symlinked launch dir) all now match; ran the actual packaged CLI through a symlinked, space-containing path — starts correctly.

**Found while re-checking the allowlist for the same shape of silent misconfiguration:** `MCP_ALLOWED_API_ORIGINS` accepted any URL scheme — a typo'd `http://` entry parsed fine and sat in the list, but could never match anything (a request's own origin is already required to be https before it reaches the allowlist check). No error, no signal the entry was dead. Now rejected at startup, same as an unparseable entry.

**Found by tabulating all four `appUrl` scenarios (request-names-backend / explicit-override / local-dev-with-identity / local-dev-stdio):** the identity branch fell back to `staticApiUrl`, which silently carries `apiUrl`'s own internal `localhost:3000` default — while the no-identity/stdio branch correctly falls back to `explicitApiUrl` alone before its own `localhost:8082` default. The two branches disagreed on the exact same "nothing configured" case: direct-mode-over-HTTP with a PAT identity and no `TOOLJET_URL` set would silently produce app-facing links on the API's port instead of the UI's. Now falls through to `explicitApiUrl` then `localhost:8082`, matching the stdio branch exactly.

## 🏗️ Architecture

```mermaid
sequenceDiagram
    participant TJ as ToolJet (any backend)
    participant Agent as tooljet-agent
    participant MCP as tooljet-mcp (shared)

    TJ->>Agent: open socket (session, workspace, own domain)
    Agent->>MCP: MCP request<br/>x-tooljet-session, x-tooljet-workspace-id,<br/>x-tooljet-url: https://<this-TJ's-own-domain>
    Note over MCP: apiUrl = request's x-tooljet-url, IF its origin is in<br/>MCP_ALLOWED_API_ORIGINS (else rejected)<br/>falls back to static TOOLJET_URL if no header sent
    MCP-->>TJ: REST calls (create page, add query, ...)<br/>land in the CALLING instance, not a fixed one
```

## Design considerations

- **Why a header, not just an env var flag?** A static env var is one value per process. The whole problem is that one shared process needs a *different* target per request — the header is the only way for that information to travel per-request at all. `MCP_REQUIRE_REQUEST_URL` alone has nothing to enforce without it.
- **Why not derive the target from the PAT or session token?** Both are opaque — a token proves *who*, never *where*. There was no existing per-request signal to carry a domain, so this adds one explicitly rather than overloading an identity field with a second meaning.
- **Why fall back to static `TOOLJET_URL` instead of always requiring the header?** Keeps every existing deployment (stdio, direct-mode, a dev's own laptop) working unchanged — those are genuinely one-operator-one-backend and have no "request" to carry a URL from.
- **Why a separate opt-in flag instead of always refusing a missing header?** Mirrors the existing `MCP_REQUIRE_USER_SESSION` pattern — a deployment that isn't ready to require the header yet keeps today's fallback behavior; one that is can turn on strict mode without a code change.
- **Why a host allowlist, and why fail closed when it's unset?** This header gets the caller's session cookie or PAT attached and sent straight to it (`auth.ts`) — a bearer-grade credential, not just traffic. `https:`-only isn't enough: an attacker's own domain has a valid cert too. `MCP_ALLOWED_API_ORIGINS` (comma-separated https origins) is the actual trust boundary; unset means empty, not "allow anything," so a deployment must opt in to which backends it will ever write into rather than defaulting open.
- **Why allow a path prefix instead of requiring a bare origin?** ToolJet supports `SUB_PATH` hosting (`server/src/main.ts`), and URLs are built as `${apiUrl}${path}` (`auth.ts`) — a self-hosted customer reverse-proxied at `https://tj.example.com/tooljet` is exactly the population this PR targets. The allowlist matches on origin only (the trust boundary); the path is the operator's own reverse-proxy detail. Query, hash, and credentials stay rejected outright; a trailing slash is normalized away.
- **Why check for `identity?.pat || identity?.sessionToken` instead of `identity` truthiness at the gates?** A request carrying only `x-tooljet-url` (no session, no PAT) produces a truthy `identity` object now that it has an `apiUrl` field. Gating on truthiness alone let that walk straight past the "must act on behalf of a signed-in user" check with nobody actually signed in.
- **Why is `MCP_REQUIRE_REQUEST_URL` enforced in `index.ts` instead of `loadConfig`?** `loadConfig` can't tell a genuine stdio call (identity omitted on purpose — one operator, static URL is correct) apart from an HTTP request that simply sent no headers at all (identity also arrives as `undefined`). Only the HTTP layer that built `identity` from a real request knows which case it is, so the flag has to live there to actually be reachable.

## 🔀 Changes

- Added `apiUrl` to `RequestIdentity`, sourced from a new `x-tooljet-url` header (`BASE_URL_HEADER`), validated and normalized by `validateApiUrl` (https-only, origin must be on `MCP_ALLOWED_API_ORIGINS`, path prefix allowed, query/hash/credentials rejected, trailing slash stripped).
- `loadConfig` now prefers the request's `apiUrl` over the static `TOOLJET_URL` when present.
- Added `MCP_REQUIRE_REQUEST_URL`, enforced in `index.ts`: refuses a gateway-mode request with no `x-tooljet-url` rather than silently falling back to a static `TOOLJET_URL`.
- Fixed the existing `MCP_REQUIRE_USER_SESSION` gate (and the direct-mode "nothing to act as" check) to test for an actual credential rather than identity-object truthiness.
- Added `config.test.ts` coverage for `x-tooljet-url` parsing, subpath/trailing-slash handling, allowlist accept/reject/unset, and static-vs-request precedence.
- `allowedApiOrigins()` normalizes every `MCP_ALLOWED_API_ORIGINS` entry via `new URL(entry).origin`; throws naming the bad entry on anything unparseable, checked once at `index.ts` startup.
- Renamed `TOOLJET_APP_URL` → `TOOLJET_DEPLOYMENT_URL` (old name still works); falls back to `TOOLJET_URL` when neither is set. Updated `README.md`, `docs/contracts.md`, `.env.example`, and the plugin manifests (`.mcp.json`, `mcp.json`, `.claude-plugin/plugin.json` — also dropped a hardcoded shell-level default there that would've defeated the new fallback for plugin users).
- Fixed `appUrl` to follow the per-request `apiUrl` in the identity branch instead of the server's own static config; an explicit `TOOLJET_DEPLOYMENT_URL`/`TOOLJET_APP_URL` still overrides it.
- Split `createGatewayHttpServer` out of `serveHttp` (`index.ts`) so the gateway HTTP request handler is testable on its own, real-request basis — same shape as `httpServer.ts`'s factory.
- Guarded `index.ts`'s top-level `main()` call to only run as the CLI entrypoint, not on import (was firing as a side effect of importing `createGatewayHttpServer` for tests).
- Added `tests/index.test.ts`: 11 tests against a live ephemeral-port server — bearer gate, both previously-raised bypasses each pinned with a real HTTP request, direct-mode credential handling.

## 🧪 How to test

- [x] `tsc --noEmit` passes clean
- [x] `vitest run` — 610 passing, no regressions
- [x] Manual: set a `http://` entry in `MCP_ALLOWED_API_ORIGINS` and confirm the server refuses to start
- [x] Manual: run direct-mode-over-HTTP with a PAT identity, no `TOOLJET_URL` set, and confirm app-facing links use `localhost:8082`, not `localhost:3000`
- [x] Manual: on a shared/gateway deployment, send two requests with different `x-tooljet-url` values and confirm any returned app-facing link (datasource settings, editor/viewer URL) matches each request's own instance, not the server's static config
- [x] Manual: set `MCP_ALLOWED_API_ORIGINS`, send a request with a listed `x-tooljet-url`, confirm it overrides `TOOLJET_URL`
- [x] Manual: send `x-tooljet-url` for an origin NOT on the allowlist (including a well-formed https one) and confirm it's rejected
- [x] Manual: leave `MCP_ALLOWED_API_ORIGINS` unset and confirm every `x-tooljet-url` is rejected, not silently allowed
- [x] Manual: set an allowlist entry with different casing/trailing-slash/`:443` and confirm it still matches
- [x] Manual: set an unparseable `MCP_ALLOWED_API_ORIGINS` entry and confirm the server refuses to start, naming the bad entry
- [x] Manual: set `MCP_REQUIRE_REQUEST_URL=true`, omit the header, confirm a loud refusal instead of a silent fallback
- [x] Manual: send an allowlisted origin with a path prefix (subpath deployment) and confirm it's accepted
- [x] Manual: send `x-tooljet-url: http://...`, a URL with a query string, and garbage input — confirm all three are rejected
- [x] Manual: set only `TOOLJET_URL` (no app/deployment URL) and confirm app-facing links use it
- [x] Deployed to `mcp-stage` and verified a clean startup log





