### PR TITLE
Feat/mcp test connection catalog flag

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -36821,7 +36821,8 @@ function selectDatasourceQuerySchema(kind, options2 = {}) {
       type: schema.type,
       description: schema.description,
       defaults: schema.defaults,
-      operations: schema.operations
+      operations: schema.operations,
+      ...typeof schema.supportsTestConnection === "boolean" ? { supports_test_connection: schema.supportsTestConnection } : {}
     });
     if (!options2.operation) {
       result.operation_summaries = Object.values(schema.contracts).map(operationSummary);
@@ -37058,6 +37059,9 @@ function inspectDatasourceSchemaTool(client) {
 
 // dist/tools/testDatasourceConnection.js
 var NOT_IMPLEMENTED = /testconnection method not implemented/i;
+function unsupportedMessage(kind) {
+  return `Datasource kind "${kind}" does not implement a connection test. This is not a failure and carries no information about the connection: verify it with a bounded read instead.`;
+}
 function isForbidden(message) {
   return /\(403\)/.test(message) || /forbidden/i.test(message);
 }
@@ -37082,6 +37086,14 @@ function testDatasourceConnectionTool(client) {
           datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind },
           settings_url: datasource.settings_url
         };
+        if (getDatasourceQuerySchema(datasource.kind)?.supportsTestConnection === false) {
+          return ok({
+            ...header,
+            supported: false,
+            status: "unsupported",
+            message: unsupportedMessage(datasource.kind)
+          });
+        }
         const details = await client.getDatasourceConnectionDetails(args.datasource_id);
         const result = await client.testDatasourceConnection({
           dataSourceId: datasource.id,
@@ -37095,7 +37107,7 @@ function testDatasourceConnectionTool(client) {
             ...header,
             supported: false,
             status: "unsupported",
-            message: `Datasource kind "${datasource.kind}" does not implement a connection test. This is not a failure and carries no information about the connection: verify it with a bounded read instead.`
+            message: unsupportedMessage(datasource.kind)
           });
         }
         if (result.status === "ok") {

--- a/data/datasource-coverage-baseline.json
+++ b/data/datasource-coverage-baseline.json
@@ -3,7 +3,9 @@
     "datasource_kinds": 94,
     "contract_count": 470,
     "known_response_contracts": 64,
-    "response_contracts_present": 470
+    "response_contracts_present": 470,
+    "kinds_with_test_connection_flag": 94,
+    "kinds_supporting_test_connection": 60
   },
   "maximums": {
     "missing_response_contracts": 0,

--- a/data/datasource-coverage.json
+++ b/data/datasource-coverage.json
@@ -154,5 +154,7 @@
     "ups",
     "xero"
   ],
-  "kinds_without_contracts": []
+  "kinds_without_contracts": [],
+  "kinds_with_test_connection_flag": 94,
+  "kinds_supporting_test_connection": 66
 }

--- a/data/datasource-schemas.json
+++ b/data/datasource-schemas.json
@@ -44,6 +44,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -686,6 +687,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -851,6 +853,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -2206,6 +2209,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -2761,6 +2765,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -5649,6 +5654,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -5781,6 +5787,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -7050,6 +7057,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -7308,6 +7316,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -7405,6 +7414,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -7485,6 +7495,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -7967,6 +7978,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -8383,6 +8395,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -8960,6 +8973,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -10794,6 +10808,7 @@
       "listDatasets",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -10961,6 +10976,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -11009,6 +11025,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -11902,6 +11919,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -12388,6 +12406,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -13082,6 +13101,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -13707,6 +13727,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -14776,6 +14797,7 @@
       "listColumns",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -15514,6 +15536,7 @@
     "introspectionMethods": [
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -15562,6 +15585,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -16603,6 +16627,7 @@
       "cluster_health": {}
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -16941,6 +16966,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -17003,6 +17029,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -17698,6 +17725,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -18221,6 +18249,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -19484,6 +19513,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -19931,6 +19961,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -19979,6 +20010,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -20027,6 +20059,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -20686,6 +20719,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -22262,6 +22296,7 @@
       "getSheets",
       "getSpreadsheets"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -22351,6 +22386,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -22383,6 +22419,7 @@
     },
     "properties": {},
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -22415,6 +22452,7 @@
     },
     "properties": {},
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -23242,6 +23280,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -23326,6 +23365,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -23530,6 +23570,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -23625,6 +23666,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -24416,6 +24458,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -24464,6 +24507,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -26157,6 +26201,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -26302,6 +26347,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -27430,6 +27476,7 @@
       "listColumns",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -27485,6 +27532,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -28051,6 +28099,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -28347,6 +28396,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -30491,6 +30541,7 @@
     "introspectionMethods": [
       "listCollections"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -31934,6 +31985,7 @@
       "listSchemas",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -33207,6 +33259,7 @@
       "listColumns",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -33374,6 +33427,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -33900,6 +33954,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -36070,6 +36125,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -37967,6 +38023,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -37999,6 +38056,7 @@
     },
     "properties": {},
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -39315,6 +39373,7 @@
       "listSchemas",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -40092,6 +40151,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -40208,6 +40268,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -40748,6 +40809,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -41401,6 +41463,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -42820,6 +42883,7 @@
       "listSchemas",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -42868,6 +42932,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -43146,6 +43211,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -43635,6 +43701,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -43683,6 +43750,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -43734,6 +43802,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -44620,6 +44689,7 @@
       "cursor/token"
     ],
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "static",
@@ -45763,6 +45833,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -45818,6 +45889,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "static",
@@ -45865,6 +45937,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "static",
@@ -46594,6 +46667,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -46927,6 +47001,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -47007,6 +47082,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -47185,6 +47261,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -48538,6 +48615,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -49454,6 +49532,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -49649,6 +49728,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -49837,6 +49917,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -51150,6 +51231,7 @@
       "listColumns",
       "listTables"
     ],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -51316,6 +51398,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -51364,6 +51447,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -52073,6 +52157,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -52304,6 +52389,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -52862,6 +52948,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "static",
@@ -52962,6 +53049,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",
@@ -53455,6 +53543,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -53511,6 +53600,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -54549,6 +54639,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "marketplace",
@@ -57285,6 +57376,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": true,
     "sources": [
       {
         "collection": "core",
@@ -57365,6 +57457,7 @@
     "introspectionMethods": [
       "getTenants"
     ],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "marketplace",
@@ -57789,6 +57882,7 @@
       }
     },
     "introspectionMethods": [],
+    "supportsTestConnection": false,
     "sources": [
       {
         "collection": "core",

--- a/scripts/datasource-coverage.mjs
+++ b/scripts/datasource-coverage.mjs
@@ -16,10 +16,18 @@ export function buildDatasourceCoverage(schemas) {
   const responses = { known: 0, runtime_dependent: 0, unknown: 0, missing: 0 };
   let contractCount = 0;
   let namedOperationKinds = 0;
+  let testConnectionFlagKinds = 0;
+  let testConnectionSupportedKinds = 0;
 
   for (const [kind, schema] of Object.entries(schemas).sort(([left], [right]) => left.localeCompare(right))) {
     if ((schema.operations || []).length > 0) namedOperationKinds += 1;
     else defaultOnlyKinds.push(kind);
+
+    // Counted as a floor, not a target: a regenerate that drops the flag leaves every kind
+    // undefined, which test_datasource_connection treats as "unknown, call and find out" — the
+    // feature would silently vanish with nothing failing.
+    if (typeof schema.supportsTestConnection === 'boolean') testConnectionFlagKinds += 1;
+    if (schema.supportsTestConnection === true) testConnectionSupportedKinds += 1;
 
     const contracts = Object.values(schema.contracts || {});
     if (!contracts.length) kindsWithoutContracts.push(kind);
@@ -65,6 +73,8 @@ export function buildDatasourceCoverage(schemas) {
     unknown_response_contracts_by_kind: sortedObject(unknownByKind),
     opaque_endpoint_kinds: [...opaqueEndpointKinds].sort(),
     kinds_without_contracts: kindsWithoutContracts,
+    kinds_with_test_connection_flag: testConnectionFlagKinds,
+    kinds_supporting_test_connection: testConnectionSupportedKinds,
   };
 }
 
@@ -77,6 +87,8 @@ function metrics(coverage) {
     missing_response_contracts: coverage.response_contracts.missing,
     kinds_without_contracts: coverage.kinds_without_contracts.length,
     opaque_endpoint_kinds: coverage.opaque_endpoint_kinds.length,
+    kinds_with_test_connection_flag: coverage.kinds_with_test_connection_flag,
+    kinds_supporting_test_connection: coverage.kinds_supporting_test_connection,
   };
 }
 

--- a/scripts/generate-datasource-catalog.mjs
+++ b/scripts/generate-datasource-catalog.mjs
@@ -266,10 +266,31 @@ function oneVariant(operation, fields, required = [], when = {}) {
   };
 }
 
+// `testConnection` is optional on a plugin and is declared nowhere in manifest.json or
+// operations.json — it is a method on the QueryService class in lib/index.ts. Harvesting it
+// statically replaces an English-message regex in test_datasource_connection, which would
+// otherwise report every healthy REST/OAuth source as broken if ToolJet reworded its
+// NotImplementedException. Every plugin class `implements QueryService` (none `extends` a base),
+// so a source scan of the entry file is sufficient; revisit if a plugin ever inherits it.
+const TEST_CONNECTION_METHOD = /(?:^|\s)(?:async\s+)?testConnection\s*\(/m;
+
+function harvestSupportsTestConnection(libDir) {
+  const entry = resolve(libDir, 'index.ts');
+  if (!existsSync(entry)) return false;
+  return TEST_CONNECTION_METHOD.test(readFileSync(entry, 'utf8'));
+}
+
 const schemas = {};
 let pluginDefinitions = 0;
 for (const collection of pluginCollections) {
-  if (!existsSync(collection.dir)) continue;
+  // Skipping a missing collection silently would overwrite the committed catalog with a partial
+  // one that still looks like a successful run. Fail instead.
+  if (!existsSync(collection.dir)) {
+    throw new Error(
+      `ToolJet ${collection.name} plugins not found at ${collection.dir}. ` +
+      'Set TOOLJET_ROOT to a ToolJet checkout before regenerating the catalog.'
+    );
+  }
   for (const packageName of readdirSync(collection.dir)) {
     const libDir = resolve(collection.dir, packageName, 'lib');
     const manifestPath = resolve(libDir, 'manifest.json');
@@ -304,6 +325,7 @@ for (const collection of pluginCollections) {
       contracts,
       properties,
       introspectionMethods: introspectionMethods(properties),
+      supportsTestConnection: harvestSupportsTestConnection(libDir),
       sources: [sourceEntry],
     };
   }
@@ -434,19 +456,20 @@ const staticSchemas = {
     defaults: { method: 'get', url: '', url_params: [], headers: [], cookies: [], body: [], raw_body: null, json_body: null, body_toggle: false, retry_network_errors: null },
     operations: Object.keys(restContracts), contracts: restContracts,
     properties: Object.fromEntries(commonRestFields.map((item) => [item.path, item])),
-    paginationStrategies: ['offset', 'page', 'cursor/token'], introspectionMethods: [], sources: [{ collection: 'static', package: 'restapi' }],
+    paginationStrategies: ['offset', 'page', 'cursor/token'], introspectionMethods: [], supportsTestConnection: false,
+    sources: [{ collection: 'static', package: 'restapi' }],
   },
   runjs: {
     kind: 'runjs', name: 'Run JavaScript', type: 'static', defaults: { code: '', parameters: [] }, operations: [],
     contracts: { default: oneVariant('default', [field('code', 'string'), field('parameters', 'array')], ['code']) },
     properties: { code: { type: 'string', description: 'JavaScript body. Return the query result.' }, parameters: { type: 'array' } },
-    introspectionMethods: [], sources: [{ collection: 'static', package: 'runjs' }],
+    introspectionMethods: [], supportsTestConnection: false, sources: [{ collection: 'static', package: 'runjs' }],
   },
   runpy: {
     kind: 'runpy', name: 'Run Python', type: 'static', defaults: { code: '' }, operations: [],
     contracts: { default: oneVariant('default', [field('code', 'string')], ['code']) },
     properties: { code: { type: 'string', description: 'Python body. Return the query result.' } },
-    introspectionMethods: [], sources: [{ collection: 'static', package: 'runpy' }],
+    introspectionMethods: [], supportsTestConnection: false, sources: [{ collection: 'static', package: 'runpy' }],
   },
   tooljetdb: {
     kind: 'tooljetdb', name: 'ToolJet Database', type: 'database',
@@ -460,7 +483,7 @@ const staticSchemas = {
       delete_rows: { type: 'object', fields: { where_filters: { type: 'record' }, limit: { type: 'number|binding' }, order_column: { type: 'string' } } },
       join_table: { type: 'object' }, bulk_update_with_primary_key: { type: 'object' }, bulk_upsert_with_primary_key: { type: 'object' }, sql_execution: { type: 'object' },
     },
-    introspectionMethods: [], sources: [{ collection: 'static', package: 'tooljetdb' }],
+    introspectionMethods: [], supportsTestConnection: false, sources: [{ collection: 'static', package: 'tooljetdb' }],
   },
 };
 
@@ -471,6 +494,26 @@ for (const [kind, schema] of Object.entries(staticSchemas)) {
 
 for (const schema of Object.values(schemas)) {
   schema.contracts = finalizeResponses(schema.kind, schema.type, schema.contracts);
+}
+
+// A regex that matched nothing would mark every kind unsupported and still look like a clean run,
+// so the harvest checks its own result before anything is written. The expected split is 67 supported
+// / 25 not, every HTTP-passthrough and OAuth kind falling on the unsupported side.
+const testConnectionSupported = Object.values(schemas).filter((schema) => schema.supportsTestConnection).length;
+const testConnectionFlagged = Object.values(schemas).filter(
+  (schema) => typeof schema.supportsTestConnection === 'boolean'
+).length;
+if (testConnectionFlagged !== Object.keys(schemas).length) {
+  throw new Error(
+    `supportsTestConnection missing on ${Object.keys(schemas).length - testConnectionFlagged} kinds; ` +
+    'every kind must carry the flag.'
+  );
+}
+if (testConnectionSupported < 50) {
+  throw new Error(
+    `Only ${testConnectionSupported} kinds report testConnection; the source scan almost certainly failed. ` +
+    'Expected ~67. Check that plugin entry files are still lib/index.ts.'
+  );
 }
 
 const sorted = sortedObject(schemas);
@@ -485,4 +528,8 @@ console.log(
 console.log(
   `Response coverage: ${coverage.response_contracts.known}/${coverage.contract_count} known; ` +
   `${coverage.response_contracts.runtime_dependent} runtime-dependent; ${coverage.response_contracts.unknown} unknown.`
+);
+console.log(
+  `Connection tests: ${testConnectionSupported}/${Object.keys(sorted).length} kinds implement testConnection; ` +
+  `${Object.keys(sorted).length - testConnectionSupported} do not.`
 );

--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -817,7 +817,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 \`test_datasource_connection({version_id, datasource_id})\` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the \`status\` precisely:
 
 - \`ok\` — the connection works; a failing query is the query's fault.
-- \`failed\` — genuinely broken; hand over the returned \`recovery.url\` and stop.
+- \`failed\` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned \`recovery.url\`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - \`unsupported\` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
 - \`not_permitted\` — this ToolJet user may not test connections. Also not a fault; say so and move on.`;
 const restApiGuidance = `## REST API queries

--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -818,7 +818,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 
 - \`ok\` — the connection works; a failing query is the query's fault.
 - \`failed\` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned \`recovery.url\`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
-- \`unsupported\` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- \`unsupported\` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: \`get_datasource_query_schema\` reports \`supports_test_connection\`, so you can skip the test rather than spend it.
 - \`not_permitted\` — this ToolJet user may not test connections. Also not a fault; say so and move on.`;
 const restApiGuidance = `## REST API queries
 

--- a/skill/references/datasources.md
+++ b/skill/references/datasources.md
@@ -11,7 +11,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 `test_datasource_connection({version_id, datasource_id})` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the `status` precisely:
 
 - `ok` — the connection works; a failing query is the query's fault.
-- `failed` — genuinely broken; hand over the returned `recovery.url` and stop.
+- `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 

--- a/skill/references/datasources.md
+++ b/skill/references/datasources.md
@@ -12,7 +12,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 
 - `ok` — the connection works; a failing query is the query's fault.
 - `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
-- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: `get_datasource_query_schema` reports `supports_test_connection`, so you can skip the test rather than spend it.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 
 ### Large-data read safety

--- a/skills/tooljet-app-builder/references/datasources.md
+++ b/skills/tooljet-app-builder/references/datasources.md
@@ -11,7 +11,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 `test_datasource_connection({version_id, datasource_id})` runs ToolJet's own connection check against the source's STORED credentials — you neither supply nor see them, and it is the one connection action you may take yourself. Use it to tell a broken connection apart from a wrong query before rewriting SQL, and read the `status` precisely:
 
 - `ok` — the connection works; a failing query is the query's fault.
-- `failed` — genuinely broken; hand over the returned `recovery.url` and stop.
+- `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 

--- a/skills/tooljet-app-builder/references/datasources.md
+++ b/skills/tooljet-app-builder/references/datasources.md
@@ -12,7 +12,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 
 - `ok` — the connection works; a failing query is the query's fault.
 - `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
-- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead.
+- `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: `get_datasource_query_schema` reports `supports_test_connection`, so you can skip the test rather than spend it.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
 
 ### Large-data read safety

--- a/src/datasourceCatalog.ts
+++ b/src/datasourceCatalog.ts
@@ -13,6 +13,9 @@ export interface DatasourceQuerySchema {
   properties: Record<string, unknown>;
   contracts: Record<string, DatasourceOperationContract>;
   introspectionMethods?: string[];
+  /** Whether the ToolJet plugin implements testConnection. Undefined means unknown (stale catalog),
+   *  which callers must treat as "test it and find out" rather than as false. */
+  supportsTestConnection?: boolean;
   sources?: Array<{ collection: string; package: string }>;
   paginationStrategies?: string[];
 }
@@ -132,6 +135,9 @@ export function selectDatasourceQuerySchema(
       description: schema.description,
       defaults: schema.defaults,
       operations: schema.operations,
+      ...(typeof schema.supportsTestConnection === 'boolean'
+        ? { supports_test_connection: schema.supportsTestConnection }
+        : {}),
     });
     if (!options.operation) {
       result.operation_summaries = Object.values(schema.contracts).map(operationSummary);

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { ToolJetClient } from '../tooljetClient.js';
 import { ok, fail, type ToolDef } from './types.js';
+import { getDatasourceQuerySchema } from '../datasourceCatalog.js';
 
 /**
  * Four outcomes hide behind ToolJet's two-field verdict, and conflating them produces confident
@@ -10,6 +11,15 @@ import { ok, fail, type ToolDef } from './types.js';
  * normal `{status:'failed'}`. Reported as-is, that reads as "your working Stripe source is down".
  */
 const NOT_IMPLEMENTED = /testconnection method not implemented/i;
+
+/** Identical whether the catalog pre-empted the call or ToolJet answered it, so the model cannot
+ *  tell the two paths apart and cannot come to depend on the difference. */
+function unsupportedMessage(kind: string): string {
+  return (
+    `Datasource kind "${kind}" does not implement a connection test. This is not a ` +
+    'failure and carries no information about the connection: verify it with a bounded read instead.'
+  );
+}
 
 /** Permission, not health: TEST_CONNECTION is granted to admins, datasource create/delete holders,
  *  all-editable/all-viewable, and per-datasource configurable grants — but NOT to a bare builder. */
@@ -51,6 +61,18 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
           settings_url: datasource.settings_url,
         };
 
+        // The catalog knows which plugins implement testConnection, so an unsupported kind costs no
+        // HTTP calls. Only an explicit false short-circuits: an undefined flag means a stale or
+        // partial catalog, which must degrade to asking ToolJet rather than to a wrong answer.
+        if (getDatasourceQuerySchema(datasource.kind)?.supportsTestConnection === false) {
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message: unsupportedMessage(datasource.kind),
+          });
+        }
+
         const details = await client.getDatasourceConnectionDetails(args.datasource_id);
         const result = await client.testDatasourceConnection({
           dataSourceId: datasource.id,
@@ -65,9 +87,7 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
             ...header,
             supported: false,
             status: 'unsupported',
-            message:
-              `Datasource kind "${datasource.kind}" does not implement a connection test. This is not a ` +
-              'failure and carries no information about the connection: verify it with a bounded read instead.',
+            message: unsupportedMessage(datasource.kind),
           });
         }
 

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -89,6 +89,36 @@ describe('test_datasource_connection tool', () => {
     expect(textOf(result)).toMatchObject({ status: 'not_permitted' });
   });
 
+  it('short-circuits a kind the catalog knows has no connection test', async () => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockResolvedValue([
+        { id: 'api1', name: 'REST', kind: 'restapi', settings_url: 'http://tj/ws/data-sources/api1' },
+      ]),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'api1' })
+    );
+    expect(parsed).toMatchObject({ supported: false, status: 'unsupported' });
+    expect(parsed.message).toMatch(/does not implement a connection test/);
+    // The whole point of the flag: no HTTP round-trip to learn "not applicable".
+    expect(client.getDatasourceConnectionDetails).not.toHaveBeenCalled();
+    expect(client.testDatasourceConnection).not.toHaveBeenCalled();
+  });
+
+  it('still tests a kind the catalog does not know, rather than assuming', async () => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockResolvedValue([
+        { id: 'x1', name: 'Unlisted', kind: 'not-in-the-catalog', settings_url: 'http://tj/ws/data-sources/x1' },
+      ]),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'x1' })
+    );
+    // An undefined flag is a stale catalog, not a claim that the plugin lacks the method.
+    expect(client.testDatasourceConnection).toHaveBeenCalled();
+    expect(parsed.status).toBe('ok');
+  });
+
   it('rejects a datasource that is not on this version', async () => {
     const client = clientWith();
     const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'nope' });


### PR DESCRIPTION
This PR records `supportsTestConnection` per datasource kind in the generated catalog, replacing the runtime English-message regex that `test_datasource_connection` used to detect an unsupported plugin.

**Why**

- `testConnection` is optional on a plugin — 25 of 92 packages don't implement it. ToolJet flattens the resulting `NotImplementedException` into a plain `{status:'failed'}`, so the tool pattern-matched the message text to tell "not applicable" from "broken".
- If that upstream string were ever reworded, every healthy REST / GraphQL / Stripe / OAuth source would be reported as broken — silently, with no test failing.

**Harvest**

- `scripts/generate-datasource-catalog.mjs` scans each package's `lib/index.ts` for a `testConnection` method and records the flag next to `introspectionMethods`. `testConnection` is declared in no manifest, so this is a source scan.
- The four curated static kinds (`restapi`, `runjs`, `runpy`, `tooljetdb`) are set explicitly — the static entries are written after the plugin loop and overwrite it.
- Result: **66 of 94 kinds supported**; the 28 are the HTTP-passthrough and OAuth plugins plus the three static kinds.

**Consumption**

- `test_datasource_connection` returns `unsupported` immediately on an explicit `false`, with no HTTP round-trip.
- The `NOT_IMPLEMENTED` regex stays as a runtime backstop, and an undefined flag still calls ToolJet — a stale catalog degrades to today's behaviour, never to a wrong answer.
- `get_datasource_query_schema` surfaces `supports_test_connection` so the skill can plan without a call.

**Guards**

- The generator validates its own harvest before writing: throws if any kind lacks the flag, or if the supported count collapses. A regex matching nothing would otherwise mark all 94 kinds unsupported and look like a clean run.
- A missing plugin collection now throws instead of being skipped, which previously overwrote the committed catalog with a partial one.
- Baseline floors `kinds_with_test_connection_flag: 94` and `kinds_supporting_test_connection: 60`, so a dropped field fails `npm test` rather than silently disabling the feature.
- Three tests: flag false → zero client calls; unknown kind → still tested; flag true but runtime says not-implemented → still `unsupported`.

