### PR TITLE
feat(mcp): add PAT-authenticated app resource permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Codex should: `list_datasources` → `create_app` → `lint_app_spec` → `apply
 | Tool | Purpose |
 |---|---|
 | `list_workspaces()` / `use_workspace(workspace_id)` | Inspect or switch the active ToolJet workspace; results include its manual datasource-settings URL |
+| `manage_app_permissions(...)` | List eligible users/groups and inspect, restrict, or clear page/query/component access; mutations are confirmed and license-gated |
 | `create_app(name)` | New app + version + Home page → ids, explicit editor/viewer links, and the workspace datasource-settings URL (`app_url` remains an editor alias) |
 | `list_datasources(version_id)` | Workspace sources available automatically to new/existing apps, each with a direct settings URL; no per-app linking |
 | `get_datasource_query_schema({datasource_id, version_id, operation?, sections?})` | Fetch compact request contracts plus response shape/status when known; also supports kind lookup and batches |

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -35057,6 +35057,66 @@ function createClient(auth, config2) {
     }));
     return { app_id: full.id, name: full.name, version_id: full.editing_version?.id, pages, queries, events };
   }
+  function appPermissionPath(appId, resourceType, resourceId) {
+    const segment = resourceType === "page" ? "pages" : resourceType === "query" ? "queries" : "components";
+    return `/api/app-permissions/${encodeURIComponent(appId)}/${segment}/${encodeURIComponent(resourceId)}`;
+  }
+  async function listAppPermissionSubjects(appId) {
+    const app = encodeURIComponent(appId);
+    const [usersResponse, groupsResponse] = await Promise.all([
+      auth.authedFetch(`/api/app-permissions/${app}/pages/users`),
+      auth.authedFetch(`/api/app-permissions/${app}/pages/user-groups`)
+    ]);
+    await assertOk(usersResponse, "listAppPermissionSubjects users");
+    await assertOk(groupsResponse, "listAppPermissionSubjects groups");
+    const users = await usersResponse.json();
+    const groups = await groupsResponse.json();
+    if (!Array.isArray(users) || !Array.isArray(groups)) {
+      throw new Error("ToolJet listAppPermissionSubjects failed: expected array responses.");
+    }
+    return {
+      users: users.map((user) => ({
+        id: user.id,
+        name: [user.firstName, user.lastName].filter(Boolean).join(" ") || void 0,
+        email: user.email
+      })),
+      groups: groups.map((group) => ({
+        id: group.id,
+        name: group.name,
+        ...typeof group.count === "number" ? { count: group.count } : {}
+      }))
+    };
+  }
+  async function getAppPermission(appId, resourceType, resourceId) {
+    const res = await auth.authedFetch(appPermissionPath(appId, resourceType, resourceId));
+    await assertOk(res, "getAppPermission");
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error("ToolJet getAppPermission failed: expected an array response.");
+    }
+    return body;
+  }
+  async function setAppPermission(params) {
+    const path = appPermissionPath(params.appId, params.resourceType, params.resourceId);
+    const existing = await getAppPermission(params.appId, params.resourceType, params.resourceId);
+    const body = params.accessType === "users" ? { type: "SINGLE", users: params.subjectIds } : { type: "GROUP", groups: params.subjectIds };
+    const res = await auth.authedFetch(path, {
+      method: existing.length ? "PUT" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    await assertOk(res, "setAppPermission");
+    return getAppPermission(params.appId, params.resourceType, params.resourceId);
+  }
+  async function clearAppPermission(appId, resourceType, resourceId) {
+    const existing = await getAppPermission(appId, resourceType, resourceId);
+    if (!existing.length)
+      return;
+    const res = await auth.authedFetch(appPermissionPath(appId, resourceType, resourceId), {
+      method: "DELETE"
+    });
+    await assertOk(res, "clearAppPermission");
+  }
   async function getAppSettings(appId, versionId) {
     const app = await getApp(appId);
     const editingVersion = app.editing_version ?? app.editingVersion;
@@ -35971,6 +36031,10 @@ function createClient(auth, config2) {
     renameApp,
     getApp,
     getAppSummary,
+    listAppPermissionSubjects,
+    getAppPermission,
+    setAppPermission,
+    clearAppPermission,
     getAppSettings,
     listAppThemes,
     createAppTheme,
@@ -42218,6 +42282,120 @@ function manageThemeTool(client) {
   };
 }
 
+// dist/tools/manageAppPermissions.js
+function requireValue2(value, label) {
+  if (value === void 0)
+    throw new Error(`${label} is required for this action.`);
+  return value;
+}
+function findResource(summary, resourceType, resourceId) {
+  if (resourceType === "page") {
+    const page = summary.pages.find((candidate) => candidate.id === resourceId);
+    if (page)
+      return { type: resourceType, id: page.id, name: page.name };
+  } else if (resourceType === "query") {
+    const query = summary.queries.find((candidate) => candidate.id === resourceId);
+    if (query)
+      return { type: resourceType, id: query.id, name: query.name };
+  } else {
+    for (const page of summary.pages) {
+      const component = page.components.find((candidate) => candidate.id === resourceId);
+      if (component) {
+        return {
+          type: resourceType,
+          id: component.id,
+          name: component.name,
+          component_type: component.type,
+          page_id: page.id,
+          page_name: page.name
+        };
+      }
+    }
+  }
+  throw new Error(`${resourceType} "${resourceId}" does not belong to app "${summary.app_id}". Use get_app_summary and do not guess resource ids.`);
+}
+function normalizePermission(permissions) {
+  const permission = permissions[0];
+  if (!permission)
+    return { access: "all", permission_id: null };
+  if (permission.type === "SINGLE") {
+    return {
+      access: "users",
+      permission_id: permission.id,
+      users: (Array.isArray(permission.users) ? permission.users : []).map((entry) => entry?.user).filter(Boolean).map((user) => ({
+        id: user.id,
+        name: [user.firstName, user.lastName].filter(Boolean).join(" ") || void 0,
+        email: user.email
+      }))
+    };
+  }
+  if (permission.type === "GROUP") {
+    return {
+      access: "groups",
+      permission_id: permission.id,
+      groups: (Array.isArray(permission.groups) ? permission.groups : []).map((entry) => entry?.permissionGroup).filter(Boolean).map((group) => ({ id: group.id, name: group.name }))
+    };
+  }
+  return { access: String(permission.type ?? "unknown").toLowerCase(), permission_id: permission.id };
+}
+function manageAppPermissionsTool(client) {
+  return {
+    name: "manage_app_permissions",
+    description: "List eligible subjects, inspect, set, or clear server-enforced access for one app page, query, or component. Use list_subjects first and exact ids from get_app_summary; users/groups must already have access to the app. set restricts access to the selected users or groups. clear broadens access to every user who can access the app. Mutations require confirm:true after the user explicitly requests the exact access rule. ToolJet license gates still apply.",
+    inputSchema: {
+      action: external_exports.enum(["list_subjects", "get", "set", "clear"]),
+      app_id: external_exports.string().uuid(),
+      resource_type: external_exports.enum(["page", "query", "component"]).optional(),
+      resource_id: external_exports.string().uuid().optional(),
+      access_type: external_exports.enum(["users", "groups"]).optional(),
+      user_ids: external_exports.array(external_exports.string().uuid()).min(1).max(100).optional(),
+      group_ids: external_exports.array(external_exports.string().uuid()).min(1).max(100).optional(),
+      confirm: external_exports.boolean().optional()
+    },
+    async handler(args) {
+      try {
+        if (args.action === "list_subjects") {
+          return ok({ app_id: args.app_id, ...await client.listAppPermissionSubjects(args.app_id) });
+        }
+        const resourceType = requireValue2(args.resource_type, "resource_type");
+        const resourceId = requireValue2(args.resource_id, "resource_id");
+        const summary = await client.getAppSummary(args.app_id);
+        const resource = findResource(summary, resourceType, resourceId);
+        if (args.action === "get") {
+          const permissions2 = await client.getAppPermission(args.app_id, resourceType, resourceId);
+          return ok({ app_id: args.app_id, resource, ...normalizePermission(permissions2) });
+        }
+        if (args.confirm !== true) {
+          throw new Error(`${args.action} permission for ${resourceType} "${resource.name ?? resource.id}" requires confirm:true after explicit approval of the exact access rule.`);
+        }
+        if (args.action === "clear") {
+          await client.clearAppPermission(args.app_id, resourceType, resourceId);
+          return ok({ app_id: args.app_id, resource, access: "all", permission_id: null });
+        }
+        const accessType = requireValue2(args.access_type, "access_type");
+        const subjectIds = accessType === "users" ? args.user_ids : args.group_ids;
+        requireValue2(subjectIds, accessType === "users" ? "user_ids" : "group_ids");
+        if (accessType === "users" && args.group_ids !== void 0) {
+          throw new Error("group_ids must be omitted when access_type is users.");
+        }
+        if (accessType === "groups" && args.user_ids !== void 0) {
+          throw new Error("user_ids must be omitted when access_type is groups.");
+        }
+        const permissions = await client.setAppPermission({
+          appId: args.app_id,
+          resourceType,
+          resourceId,
+          accessType,
+          subjectIds: [...new Set(subjectIds)]
+        });
+        return ok({ app_id: args.app_id, resource, ...normalizePermission(permissions) });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+
 // dist/tools/index.js
 var LEGACY_SINGULAR_CREATE_TOOL_NAMES = /* @__PURE__ */ new Set([
   "create_table",
@@ -42234,6 +42412,7 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     getRuntimeInfoTool(runtime),
     listWorkspacesTool(client),
     useWorkspaceTool(client),
+    manageAppPermissionsTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -263,7 +263,8 @@ Don't reflexively interrogate the user. For a **common read-only dashboard on an
 - Component visibility/disable rules are UX only. Never present a hidden button, page, or modal as an access-control boundary.
 - Use server-side datasource permissions and row-level security for sensitive data. In server-executed queries, prefer \`globals.server.currentUser\` for user-scoped filters; client-side \`globals.currentUser\` can be inspected or changed by the client.
 - Server-side current-user variables are not available inside RunJS/RunPy. Do not move an authorization check into client-executed code.
-- Ask about roles/ownership before adding destructive or sensitive writes. If the MCP surface cannot configure the required query/page permission or RLS policy, state the exact manual ToolJet step instead of claiming the app is secured.
+- Ask about roles/ownership before adding destructive or sensitive writes. When the user requests page, query, or component access control, use \`manage_app_permissions\`: call \`list_subjects\`, resolve exact resource ids with \`get_app_summary\`, then use confirmed \`set\` or \`clear\`. Only users/groups that already have app access are eligible, and ToolJet license gates still apply.
+- Page permissions restrict page access, query permissions restrict execution, and component permissions restrict access to that component. These persisted permissions are different from visibility/disable expressions. Query permissions do not replace datasource permissions or row-level security; if the required authorization cannot be configured through the available surface, state the exact remaining ToolJet/RLS step instead of claiming the app is secured.
 - Never place credentials, tokens, or secrets in component properties, RunJS, query parameters, alerts, or seeded placeholder data.
 
 ## SQL parameters — never splice a component value into the statement

--- a/skill/references/security.md
+++ b/skill/references/security.md
@@ -7,7 +7,8 @@ Read this before adding sensitive data access, user-scoped behavior, permissions
 - Component visibility/disable rules are UX only. Never present a hidden button, page, or modal as an access-control boundary.
 - Use server-side datasource permissions and row-level security for sensitive data. In server-executed queries, prefer `globals.server.currentUser` for user-scoped filters; client-side `globals.currentUser` can be inspected or changed by the client.
 - Server-side current-user variables are not available inside RunJS/RunPy. Do not move an authorization check into client-executed code.
-- Ask about roles/ownership before adding destructive or sensitive writes. If the MCP surface cannot configure the required query/page permission or RLS policy, state the exact manual ToolJet step instead of claiming the app is secured.
+- Ask about roles/ownership before adding destructive or sensitive writes. When the user requests page, query, or component access control, use `manage_app_permissions`: call `list_subjects`, resolve exact resource ids with `get_app_summary`, then use confirmed `set` or `clear`. Only users/groups that already have app access are eligible, and ToolJet license gates still apply.
+- Page permissions restrict page access, query permissions restrict execution, and component permissions restrict access to that component. These persisted permissions are different from visibility/disable expressions. Query permissions do not replace datasource permissions or row-level security; if the required authorization cannot be configured through the available surface, state the exact remaining ToolJet/RLS step instead of claiming the app is secured.
 - Never place credentials, tokens, or secrets in component properties, RunJS, query parameters, alerts, or seeded placeholder data.
 
 ## SQL parameters — never splice a component value into the statement

--- a/skills/tooljet-app-builder/references/security.md
+++ b/skills/tooljet-app-builder/references/security.md
@@ -7,7 +7,8 @@ Read this before adding sensitive data access, user-scoped behavior, permissions
 - Component visibility/disable rules are UX only. Never present a hidden button, page, or modal as an access-control boundary.
 - Use server-side datasource permissions and row-level security for sensitive data. In server-executed queries, prefer `globals.server.currentUser` for user-scoped filters; client-side `globals.currentUser` can be inspected or changed by the client.
 - Server-side current-user variables are not available inside RunJS/RunPy. Do not move an authorization check into client-executed code.
-- Ask about roles/ownership before adding destructive or sensitive writes. If the MCP surface cannot configure the required query/page permission or RLS policy, state the exact manual ToolJet step instead of claiming the app is secured.
+- Ask about roles/ownership before adding destructive or sensitive writes. When the user requests page, query, or component access control, use `manage_app_permissions`: call `list_subjects`, resolve exact resource ids with `get_app_summary`, then use confirmed `set` or `clear`. Only users/groups that already have app access are eligible, and ToolJet license gates still apply.
+- Page permissions restrict page access, query permissions restrict execution, and component permissions restrict access to that component. These persisted permissions are different from visibility/disable expressions. Query permissions do not replace datasource permissions or row-level security; if the required authorization cannot be configured through the available surface, state the exact remaining ToolJet/RLS step instead of claiming the app is secured.
 - Never place credentials, tokens, or secrets in component properties, RunJS, query parameters, alerts, or seeded placeholder data.
 
 ## SQL parameters — never splice a component value into the statement

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -39,6 +39,22 @@ export interface CreateAppThemeParams {
   isDefault?: boolean;
 }
 
+export type AppPermissionResourceType = 'page' | 'query' | 'component';
+export type AppPermissionAccessType = 'users' | 'groups';
+
+export interface AppPermissionSubjects {
+  users: Array<{ id: string; name?: string; email?: string }>;
+  groups: Array<{ id: string; name?: string; count?: number }>;
+}
+
+export interface SetAppPermissionParams {
+  appId: string;
+  resourceType: AppPermissionResourceType;
+  resourceId: string;
+  accessType: AppPermissionAccessType;
+  subjectIds: string[];
+}
+
 export interface AppSettingsSnapshot {
   app_id: string;
   version_id: string;
@@ -415,6 +431,18 @@ export interface ToolJetClient {
   renameApp(appId: string, versionId: string, name: string): Promise<void>;
   getApp(appId: string): Promise<any>;
   getAppSummary(appId: string): Promise<AppSummary>;
+  listAppPermissionSubjects(appId: string): Promise<AppPermissionSubjects>;
+  getAppPermission(
+    appId: string,
+    resourceType: AppPermissionResourceType,
+    resourceId: string
+  ): Promise<Array<Record<string, unknown>>>;
+  setAppPermission(params: SetAppPermissionParams): Promise<Array<Record<string, unknown>>>;
+  clearAppPermission(
+    appId: string,
+    resourceType: AppPermissionResourceType,
+    resourceId: string
+  ): Promise<void>;
   getAppSettings(appId: string, versionId: string): Promise<AppSettingsSnapshot>;
   listAppThemes(): Promise<AppTheme[]>;
   createAppTheme(params: CreateAppThemeParams): Promise<AppTheme>;
@@ -648,6 +676,88 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
       ...(typeof e.index === 'number' ? { index: e.index } : {}),
     }));
     return { app_id: full.id, name: full.name, version_id: full.editing_version?.id, pages, queries, events };
+  }
+
+  function appPermissionPath(
+    appId: string,
+    resourceType: AppPermissionResourceType,
+    resourceId: string
+  ): string {
+    const segment =
+      resourceType === 'page' ? 'pages' : resourceType === 'query' ? 'queries' : 'components';
+    return `/api/app-permissions/${encodeURIComponent(appId)}/${segment}/${encodeURIComponent(resourceId)}`;
+  }
+
+  async function listAppPermissionSubjects(appId: string): Promise<AppPermissionSubjects> {
+    const app = encodeURIComponent(appId);
+    const [usersResponse, groupsResponse] = await Promise.all([
+      auth.authedFetch(`/api/app-permissions/${app}/pages/users`),
+      auth.authedFetch(`/api/app-permissions/${app}/pages/user-groups`),
+    ]);
+    await assertOk(usersResponse, 'listAppPermissionSubjects users');
+    await assertOk(groupsResponse, 'listAppPermissionSubjects groups');
+    const users = await usersResponse.json();
+    const groups = await groupsResponse.json();
+    if (!Array.isArray(users) || !Array.isArray(groups)) {
+      throw new Error('ToolJet listAppPermissionSubjects failed: expected array responses.');
+    }
+    return {
+      users: users.map((user: any) => ({
+        id: user.id,
+        name: [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
+        email: user.email,
+      })),
+      groups: groups.map((group: any) => ({
+        id: group.id,
+        name: group.name,
+        ...(typeof group.count === 'number' ? { count: group.count } : {}),
+      })),
+    };
+  }
+
+  async function getAppPermission(
+    appId: string,
+    resourceType: AppPermissionResourceType,
+    resourceId: string
+  ): Promise<Array<Record<string, unknown>>> {
+    const res = await auth.authedFetch(appPermissionPath(appId, resourceType, resourceId));
+    await assertOk(res, 'getAppPermission');
+    const body = await res.json();
+    if (!Array.isArray(body)) {
+      throw new Error('ToolJet getAppPermission failed: expected an array response.');
+    }
+    return body as Array<Record<string, unknown>>;
+  }
+
+  async function setAppPermission(
+    params: SetAppPermissionParams
+  ): Promise<Array<Record<string, unknown>>> {
+    const path = appPermissionPath(params.appId, params.resourceType, params.resourceId);
+    const existing = await getAppPermission(params.appId, params.resourceType, params.resourceId);
+    const body =
+      params.accessType === 'users'
+        ? { type: 'SINGLE', users: params.subjectIds }
+        : { type: 'GROUP', groups: params.subjectIds };
+    const res = await auth.authedFetch(path, {
+      method: existing.length ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    await assertOk(res, 'setAppPermission');
+    return getAppPermission(params.appId, params.resourceType, params.resourceId);
+  }
+
+  async function clearAppPermission(
+    appId: string,
+    resourceType: AppPermissionResourceType,
+    resourceId: string
+  ): Promise<void> {
+    const existing = await getAppPermission(appId, resourceType, resourceId);
+    if (!existing.length) return;
+    const res = await auth.authedFetch(appPermissionPath(appId, resourceType, resourceId), {
+      method: 'DELETE',
+    });
+    await assertOk(res, 'clearAppPermission');
   }
 
   async function getAppSettings(appId: string, versionId: string): Promise<AppSettingsSnapshot> {
@@ -1874,6 +1984,10 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     renameApp,
     getApp,
     getAppSummary,
+    listAppPermissionSubjects,
+    getAppPermission,
+    setAppPermission,
+    clearAppPermission,
     getAppSettings,
     listAppThemes,
     createAppTheme,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -59,6 +59,7 @@ import {
 } from '../runtimeFreshness.js';
 import { getRuntimeInfoTool } from './getRuntimeInfo.js';
 import { manageThemeTool } from './manageTheme.js';
+import { manageAppPermissionsTool } from './manageAppPermissions.js';
 
 export const LEGACY_SINGULAR_CREATE_TOOL_NAMES = new Set([
   'create_table',
@@ -81,6 +82,7 @@ export function registerTools(
     getRuntimeInfoTool(runtime),
     listWorkspacesTool(client),
     useWorkspaceTool(client),
+    manageAppPermissionsTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/src/tools/manageAppPermissions.ts
+++ b/src/tools/manageAppPermissions.ts
@@ -1,0 +1,153 @@
+import { z } from 'zod';
+import type {
+  AppPermissionAccessType,
+  AppPermissionResourceType,
+  AppSummary,
+  ToolJetClient,
+} from '../tooljetClient.js';
+import { fail, ok, type ToolDef } from './types.js';
+
+type ManageAppPermissionsArgs = {
+  action: 'list_subjects' | 'get' | 'set' | 'clear';
+  app_id: string;
+  resource_type?: AppPermissionResourceType;
+  resource_id?: string;
+  access_type?: AppPermissionAccessType;
+  user_ids?: string[];
+  group_ids?: string[];
+  confirm?: boolean;
+};
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`${label} is required for this action.`);
+  return value;
+}
+
+function findResource(summary: AppSummary, resourceType: AppPermissionResourceType, resourceId: string) {
+  if (resourceType === 'page') {
+    const page = summary.pages.find((candidate) => candidate.id === resourceId);
+    if (page) return { type: resourceType, id: page.id, name: page.name };
+  } else if (resourceType === 'query') {
+    const query = summary.queries.find((candidate) => candidate.id === resourceId);
+    if (query) return { type: resourceType, id: query.id, name: query.name };
+  } else {
+    for (const page of summary.pages) {
+      const component = page.components.find((candidate) => candidate.id === resourceId);
+      if (component) {
+        return {
+          type: resourceType,
+          id: component.id,
+          name: component.name,
+          component_type: component.type,
+          page_id: page.id,
+          page_name: page.name,
+        };
+      }
+    }
+  }
+  throw new Error(
+    `${resourceType} "${resourceId}" does not belong to app "${summary.app_id}". ` +
+      'Use get_app_summary and do not guess resource ids.'
+  );
+}
+
+function normalizePermission(permissions: Array<Record<string, unknown>>) {
+  const permission = permissions[0] as any;
+  if (!permission) return { access: 'all', permission_id: null };
+  if (permission.type === 'SINGLE') {
+    return {
+      access: 'users',
+      permission_id: permission.id,
+      users: (Array.isArray(permission.users) ? permission.users : [])
+        .map((entry: any) => entry?.user)
+        .filter(Boolean)
+        .map((user: any) => ({
+          id: user.id,
+          name: [user.firstName, user.lastName].filter(Boolean).join(' ') || undefined,
+          email: user.email,
+        })),
+    };
+  }
+  if (permission.type === 'GROUP') {
+    return {
+      access: 'groups',
+      permission_id: permission.id,
+      groups: (Array.isArray(permission.groups) ? permission.groups : [])
+        .map((entry: any) => entry?.permissionGroup)
+        .filter(Boolean)
+        .map((group: any) => ({ id: group.id, name: group.name })),
+    };
+  }
+  return { access: String(permission.type ?? 'unknown').toLowerCase(), permission_id: permission.id };
+}
+
+export function manageAppPermissionsTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'manage_app_permissions',
+    description:
+      'List eligible subjects, inspect, set, or clear server-enforced access for one app page, query, or ' +
+      'component. Use list_subjects first and exact ids from get_app_summary; users/groups must already have ' +
+      'access to the app. set restricts access to the selected users or groups. clear broadens access to every ' +
+      'user who can access the app. Mutations require confirm:true after the user explicitly requests the exact ' +
+      'access rule. ToolJet license gates still apply.',
+    inputSchema: {
+      action: z.enum(['list_subjects', 'get', 'set', 'clear']),
+      app_id: z.string().uuid(),
+      resource_type: z.enum(['page', 'query', 'component']).optional(),
+      resource_id: z.string().uuid().optional(),
+      access_type: z.enum(['users', 'groups']).optional(),
+      user_ids: z.array(z.string().uuid()).min(1).max(100).optional(),
+      group_ids: z.array(z.string().uuid()).min(1).max(100).optional(),
+      confirm: z.boolean().optional(),
+    },
+    async handler(args: ManageAppPermissionsArgs) {
+      try {
+        if (args.action === 'list_subjects') {
+          return ok({ app_id: args.app_id, ...(await client.listAppPermissionSubjects(args.app_id)) });
+        }
+
+        const resourceType = requireValue(args.resource_type, 'resource_type');
+        const resourceId = requireValue(args.resource_id, 'resource_id');
+        const summary = await client.getAppSummary(args.app_id);
+        const resource = findResource(summary, resourceType, resourceId);
+
+        if (args.action === 'get') {
+          const permissions = await client.getAppPermission(args.app_id, resourceType, resourceId);
+          return ok({ app_id: args.app_id, resource, ...normalizePermission(permissions) });
+        }
+
+        if (args.confirm !== true) {
+          throw new Error(
+            `${args.action} permission for ${resourceType} "${resource.name ?? resource.id}" requires ` +
+              'confirm:true after explicit approval of the exact access rule.'
+          );
+        }
+
+        if (args.action === 'clear') {
+          await client.clearAppPermission(args.app_id, resourceType, resourceId);
+          return ok({ app_id: args.app_id, resource, access: 'all', permission_id: null });
+        }
+
+        const accessType = requireValue(args.access_type, 'access_type');
+        const subjectIds = accessType === 'users' ? args.user_ids : args.group_ids;
+        requireValue(subjectIds, accessType === 'users' ? 'user_ids' : 'group_ids');
+        if (accessType === 'users' && args.group_ids !== undefined) {
+          throw new Error('group_ids must be omitted when access_type is users.');
+        }
+        if (accessType === 'groups' && args.user_ids !== undefined) {
+          throw new Error('user_ids must be omitted when access_type is groups.');
+        }
+        const permissions = await client.setAppPermission({
+          appId: args.app_id,
+          resourceType,
+          resourceId,
+          accessType,
+          subjectIds: [...new Set(subjectIds)],
+        });
+        return ok({ app_id: args.app_id, resource, ...normalizePermission(permissions) });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `manage_app_permissions` for page, query, and component permissions.
- Support listing eligible subjects and getting, setting, or clearing a resource permission.
- Use the existing PAT/session-authenticated app-permission APIs; no external access token is required.
- Validate that the resource belongs to the app and require explicit confirmation for mutations.

## Impact

- **Speed:** no additional model call; permission mutations perform the minimum API reads needed to choose create/update and return the authoritative result.
- **Quality:** exact app/resource IDs are validated, while ToolJet continues to enforce PAT scope, user role, and license checks server-side.
- **Tokens:** one compact tool schema is added; no conversation history or app-state payload is added.

## Testing

- TypeScript and plugin builds passed.
- 577 tests passed.
- PAT/session route checks covered page, query, and component list/get/set/clear flows.
- A live Grok flow successfully set, verified, cleared, and re-verified all three resource types.