### PR TITLE
feat: expose PAT-scoped workspace management

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Codex should: `list_datasources` → `create_app` → `lint_app_spec` → `apply
 | `list_workspaces()` / `use_workspace(workspace_id)` | Inspect or switch the active ToolJet workspace; results include its manual datasource-settings URL |
 | `manage_app_permissions(...)` | List eligible users/groups and inspect, restrict, or clear page/query/component access; mutations are confirmed and license-gated |
 | `list_workspace_apps(...)` | List apps in the workspace pinned to the current PAT |
-| `manage_workspace_users(...)` | List/invite/update/archive workspace users through PAT auth; mutations require confirmation and remain subject to ToolJet role checks |
+| `list_workspace_users(...)` | List/search workspace users with pagination and status filtering through PAT auth |
+| `manage_workspace_users(...)` | Invite/update/archive workspace users through PAT auth; mutations require confirmation and remain subject to ToolJet role checks |
 | `create_app(name)` | New app + version + Home page → ids, explicit editor/viewer links, and the workspace datasource-settings URL (`app_url` remains an editor alias) |
 | `list_datasources(version_id)` | Workspace sources available automatically to new/existing apps, each with a direct settings URL; no per-app linking |
 | `get_datasource_query_schema({datasource_id, version_id, operation?, sections?})` | Fetch compact request contracts plus response shape/status when known; also supports kind lookup and batches |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Codex should: `list_datasources` → `create_app` → `lint_app_spec` → `apply
 |---|---|
 | `list_workspaces()` / `use_workspace(workspace_id)` | Inspect or switch the active ToolJet workspace; results include its manual datasource-settings URL |
 | `manage_app_permissions(...)` | List eligible users/groups and inspect, restrict, or clear page/query/component access; mutations are confirmed and license-gated |
+| `list_workspace_apps(...)` | List apps in the workspace pinned to the current PAT |
+| `manage_workspace_users(...)` | List/invite/update/archive workspace users through PAT auth; mutations require confirmation and remain subject to ToolJet role checks |
 | `create_app(name)` | New app + version + Home page → ids, explicit editor/viewer links, and the workspace datasource-settings URL (`app_url` remains an editor alias) |
 | `list_datasources(version_id)` | Workspace sources available automatically to new/existing apps, each with a direct settings URL; no per-app linking |
 | `get_datasource_query_schema({datasource_id, version_id, operation?, sections?})` | Fetch compact request contracts plus response shape/status when known; also supports kind lookup and batches |

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -6448,8 +6448,8 @@ var require_discriminator = __commonJS({
           if (!tagRequired)
             throw new Error(`discriminator: "${tagName}" must be required`);
           return oneOfMapping;
-          function hasRequired({ required: required2 }) {
-            return Array.isArray(required2) && required2.includes(tagName);
+          function hasRequired({ required: required3 }) {
+            return Array.isArray(required3) && required3.includes(tagName);
           }
           function addMappings(sch, i) {
             if (sch.const) {
@@ -30228,7 +30228,7 @@ function parseObjectDef(def, refs2) {
     type: "object",
     properties: {}
   };
-  const required2 = [];
+  const required3 = [];
   const shape = def.shape();
   for (const propName in shape) {
     let propDef = shape[propName];
@@ -30255,11 +30255,11 @@ function parseObjectDef(def, refs2) {
     }
     result.properties[propName] = parsedDef;
     if (!propOptional) {
-      required2.push(propName);
+      required3.push(propName);
     }
   }
-  if (required2.length) {
-    result.required = required2;
+  if (required3.length) {
+    result.required = required3;
   }
   const additionalProperties = decideAdditionalProperties(def, refs2);
   if (additionalProperties !== void 0) {
@@ -35005,6 +35005,61 @@ function tableForeignKeyDto(foreignKey) {
 function createClient(auth, config2) {
   let developmentEnvironmentIdPromise;
   const datasourceManagementUrl = (workspaceSlug, datasourceId) => `${config2.appUrl}/${encodeURIComponent(workspaceSlug)}/data-sources` + (datasourceId ? `/${encodeURIComponent(datasourceId)}` : "");
+  async function listWorkspaceApps(params = {}) {
+    const query = new URLSearchParams({ page: String(params.page ?? 1), type: "front-end" });
+    if (params.searchText)
+      query.set("searchKey", params.searchText);
+    const res = await auth.authedFetch(`/api/apps?${query}`);
+    await assertOk(res, "listWorkspaceApps");
+    return await res.json();
+  }
+  async function listWorkspaceUsers(params = {}) {
+    const query = new URLSearchParams({ page: String(params.page ?? 1) });
+    if (params.searchText)
+      query.set("searchText", params.searchText);
+    if (params.status)
+      query.set("status", params.status);
+    const res = await auth.authedFetch(`/api/organization-users?${query}`);
+    await assertOk(res, "listWorkspaceUsers");
+    return await res.json();
+  }
+  async function inviteWorkspaceUser(params) {
+    const res = await auth.authedFetch("/api/organization-users", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: params.email,
+        role: params.role,
+        ...params.firstName !== void 0 ? { firstName: params.firstName } : {},
+        ...params.lastName !== void 0 ? { lastName: params.lastName } : {},
+        ...params.groupIds !== void 0 ? { groups: params.groupIds } : {}
+      })
+    });
+    await assertOk(res, "inviteWorkspaceUser");
+  }
+  async function updateWorkspaceUser(organizationUserId, params) {
+    const res = await auth.authedFetch(`/api/organization-users/${encodeURIComponent(organizationUserId)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...params.firstName !== void 0 ? { firstName: params.firstName } : {},
+        ...params.lastName !== void 0 ? { lastName: params.lastName } : {},
+        ...params.role !== void 0 ? { role: params.role } : {},
+        addGroups: params.addGroupIds ?? [],
+        ...params.userMetadata !== void 0 ? { userMetadata: params.userMetadata } : {}
+      })
+    });
+    await assertOk(res, "updateWorkspaceUser");
+  }
+  async function setWorkspaceUserArchived(organizationUserId, archived) {
+    const action = archived ? "archive" : "unarchive";
+    const res = await auth.authedFetch(`/api/organization-users/${encodeURIComponent(organizationUserId)}/${action}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}"
+    });
+    await assertOk(res, `${action}WorkspaceUser`);
+  }
   async function getApp(appId) {
     const res = await auth.authedFetch(`/api/apps/${appId}`);
     await assertOk(res, "getApp");
@@ -36027,6 +36082,11 @@ function createClient(auth, config2) {
   return {
     listWorkspaces,
     useWorkspace,
+    listWorkspaceApps,
+    listWorkspaceUsers,
+    inviteWorkspaceUser,
+    updateWorkspaceUser,
+    setWorkspaceUserArchived,
     createApp,
     renameApp,
     getApp,
@@ -36854,9 +36914,9 @@ function getDatasourceQuerySchema(kind) {
 }
 function operationSummary(contract) {
   const selectors = {};
-  const required2 = /* @__PURE__ */ new Set();
+  const required3 = /* @__PURE__ */ new Set();
   for (const variant of contract.variants) {
-    variant.required.forEach((path) => required2.add(path));
+    variant.required.forEach((path) => required3.add(path));
     for (const [key, values] of Object.entries(variant.when)) {
       const collected = selectors[key] ?? /* @__PURE__ */ new Set();
       values.forEach((value) => collected.add(value));
@@ -36866,7 +36926,7 @@ function operationSummary(contract) {
   return {
     operation: contract.operation,
     selectors: Object.fromEntries(Object.entries(selectors).map(([key, values]) => [key, [...values].sort()])),
-    required: [...required2].sort(),
+    required: [...required3].sort(),
     variants: contract.variants.length,
     ...contract.response ? { response_type: contract.response.type } : {},
     ...contract.response ? { response_status: contract.response.status } : {}
@@ -38028,7 +38088,7 @@ function validateEvents(summary, events, options2 = {}) {
               errors.push(`${label}: every componentSpecificActionParams entry requires a string handle.`);
             }
             const requiredHandles = (componentAction.params ?? []).flatMap((param) => nonEmptyString(param.handle) ? [param.handle] : []);
-            const missing = requiredHandles.filter((required2) => !supplied.has(required2));
+            const missing = requiredHandles.filter((required3) => !supplied.has(required3));
             if (missing.length) {
               errors.push(`${label}: control-component action "${handle}" is missing parameter handles: ${missing.join(", ")}.`);
             }
@@ -38900,8 +38960,8 @@ function validateQueryOptions(kind, options2) {
       }
     }
   }
-  const required2 = intersection2(matching.map((variant) => variant.required));
-  for (const path of required2) {
+  const required3 = intersection2(matching.map((variant) => variant.required));
+  for (const path of required3) {
     const value = valueAtPath(options2, path);
     if (value === void 0 || value === null || value === "") {
       errors.push({
@@ -42396,6 +42456,106 @@ function manageAppPermissionsTool(client) {
   };
 }
 
+// dist/tools/workspaceUserManagement.js
+var userRole = external_exports.enum(["admin", "builder", "end-user"]);
+var userStatus = external_exports.enum(["active", "archived", "invited"]);
+function listWorkspaceAppsTool(client) {
+  return {
+    name: "list_workspace_apps",
+    description: "List apps in the workspace pinned to the current ToolJet PAT. This cannot inspect or switch to another workspace.",
+    inputSchema: {
+      page: external_exports.number().int().positive().optional(),
+      search_text: external_exports.string().trim().max(100).optional()
+    },
+    async handler(args) {
+      try {
+        return ok(await client.listWorkspaceApps({ page: args.page, searchText: args.search_text }));
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+function listWorkspaceUsersTool(client) {
+  return {
+    name: "list_workspace_users",
+    description: "List users in the workspace pinned to the current ToolJet PAT. Supports pagination, search, and status filtering.",
+    inputSchema: {
+      page: external_exports.number().int().positive().optional(),
+      search_text: external_exports.string().trim().max(100).optional(),
+      filter_status: userStatus.optional()
+    },
+    async handler(args) {
+      try {
+        return ok(await client.listWorkspaceUsers({
+          page: args.page,
+          searchText: args.search_text,
+          status: args.filter_status
+        }));
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+function required2(value, label) {
+  if (!value)
+    throw new Error(`${label} is required for this action.`);
+  return value;
+}
+function manageWorkspaceUsersTool(client) {
+  return {
+    name: "manage_workspace_users",
+    description: "Manage users only in the workspace pinned to the current ToolJet PAT. Invite, update, archive, and unarchive require confirm:true. Updates can change names/role and add existing custom groups; they cannot remove groups, change passwords, manage other workspaces, or bypass the PAT owner's ToolJet permissions.",
+    inputSchema: {
+      action: external_exports.enum(["invite", "update", "archive", "unarchive"]),
+      organization_user_id: external_exports.string().uuid().optional(),
+      email: external_exports.string().email().optional(),
+      first_name: external_exports.string().trim().max(99).optional(),
+      last_name: external_exports.string().trim().max(99).optional(),
+      role: userRole.optional(),
+      group_ids: external_exports.array(external_exports.string().uuid()).max(100).optional(),
+      user_metadata: external_exports.record(external_exports.string(), external_exports.unknown()).optional(),
+      confirm: external_exports.boolean().optional()
+    },
+    async handler(args) {
+      try {
+        if (args.confirm !== true) {
+          throw new Error(`${args.action} requires confirm:true after checking the exact workspace user.`);
+        }
+        if (args.action === "invite") {
+          await client.inviteWorkspaceUser({
+            email: required2(args.email, "email"),
+            role: args.role ?? "end-user",
+            firstName: args.first_name,
+            lastName: args.last_name,
+            groupIds: args.group_ids
+          });
+          return ok({ invited: true, email: args.email });
+        }
+        const organizationUserId = required2(args.organization_user_id, "organization_user_id");
+        if (args.action === "archive" || args.action === "unarchive") {
+          await client.setWorkspaceUserArchived(organizationUserId, args.action === "archive");
+          return ok({ organization_user_id: organizationUserId, status: args.action === "archive" ? "archived" : "active" });
+        }
+        if (args.first_name === void 0 && args.last_name === void 0 && args.role === void 0 && args.group_ids === void 0 && args.user_metadata === void 0) {
+          throw new Error("update requires at least one changed field.");
+        }
+        await client.updateWorkspaceUser(organizationUserId, {
+          firstName: args.first_name,
+          lastName: args.last_name,
+          role: args.role,
+          addGroupIds: args.group_ids,
+          userMetadata: args.user_metadata
+        });
+        return ok({ organization_user_id: organizationUserId, updated: true });
+      } catch (error51) {
+        return fail(error51);
+      }
+    }
+  };
+}
+
 // dist/tools/index.js
 var LEGACY_SINGULAR_CREATE_TOOL_NAMES = /* @__PURE__ */ new Set([
   "create_table",
@@ -42413,6 +42573,9 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     listWorkspacesTool(client),
     useWorkspaceTool(client),
     manageAppPermissionsTool(client),
+    listWorkspaceAppsTool(client),
+    listWorkspaceUsersTool(client),
+    manageWorkspaceUsersTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -55,6 +55,43 @@ export interface SetAppPermissionParams {
   subjectIds: string[];
 }
 
+export type WorkspaceUserStatus = 'active' | 'archived' | 'invited';
+export type WorkspaceUserRole = 'admin' | 'builder' | 'end-user';
+
+export interface WorkspaceUser {
+  id: string;
+  user_id?: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  name?: string;
+  role?: WorkspaceUserRole;
+  status?: WorkspaceUserStatus;
+  groups?: Array<{ id: string; name: string }>;
+  [key: string]: unknown;
+}
+
+export interface WorkspaceUsersPage {
+  meta: { total_pages: number; total_count: number; current_page: number };
+  users: WorkspaceUser[];
+}
+
+export interface InviteWorkspaceUserParams {
+  email: string;
+  role: WorkspaceUserRole;
+  firstName?: string;
+  lastName?: string;
+  groupIds?: string[];
+}
+
+export interface UpdateWorkspaceUserParams {
+  firstName?: string;
+  lastName?: string;
+  role?: WorkspaceUserRole;
+  addGroupIds?: string[];
+  userMetadata?: Record<string, unknown>;
+}
+
 export interface AppSettingsSnapshot {
   app_id: string;
   version_id: string;
@@ -427,6 +464,15 @@ export interface QuerySummary {
 export interface ToolJetClient {
   listWorkspaces(): Promise<Workspace[]>;
   useWorkspace(workspaceId: string): Promise<Workspace>;
+  listWorkspaceApps(params?: { page?: number; searchText?: string }): Promise<Record<string, unknown>>;
+  listWorkspaceUsers(params?: {
+    page?: number;
+    searchText?: string;
+    status?: WorkspaceUserStatus;
+  }): Promise<WorkspaceUsersPage>;
+  inviteWorkspaceUser(params: InviteWorkspaceUserParams): Promise<void>;
+  updateWorkspaceUser(organizationUserId: string, params: UpdateWorkspaceUserParams): Promise<void>;
+  setWorkspaceUserArchived(organizationUserId: string, archived: boolean): Promise<void>;
   createApp(name: string): Promise<CreateAppResult>;
   renameApp(appId: string, versionId: string, name: string): Promise<void>;
   getApp(appId: string): Promise<any>;
@@ -618,6 +664,73 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   const datasourceManagementUrl = (workspaceSlug: string, datasourceId?: string) =>
     `${config.appUrl}/${encodeURIComponent(workspaceSlug)}/data-sources` +
     (datasourceId ? `/${encodeURIComponent(datasourceId)}` : '');
+
+  async function listWorkspaceApps(
+    params: { page?: number; searchText?: string } = {}
+  ): Promise<Record<string, unknown>> {
+    const query = new URLSearchParams({ page: String(params.page ?? 1), type: 'front-end' });
+    if (params.searchText) query.set('searchKey', params.searchText);
+    const res = await auth.authedFetch(`/api/apps?${query}`);
+    await assertOk(res, 'listWorkspaceApps');
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  async function listWorkspaceUsers(
+    params: { page?: number; searchText?: string; status?: WorkspaceUserStatus } = {}
+  ): Promise<WorkspaceUsersPage> {
+    const query = new URLSearchParams({ page: String(params.page ?? 1) });
+    if (params.searchText) query.set('searchText', params.searchText);
+    if (params.status) query.set('status', params.status);
+    const res = await auth.authedFetch(`/api/organization-users?${query}`);
+    await assertOk(res, 'listWorkspaceUsers');
+    return (await res.json()) as WorkspaceUsersPage;
+  }
+
+  async function inviteWorkspaceUser(params: InviteWorkspaceUserParams): Promise<void> {
+    const res = await auth.authedFetch('/api/organization-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: params.email,
+        role: params.role,
+        ...(params.firstName !== undefined ? { firstName: params.firstName } : {}),
+        ...(params.lastName !== undefined ? { lastName: params.lastName } : {}),
+        ...(params.groupIds !== undefined ? { groups: params.groupIds } : {}),
+      }),
+    });
+    await assertOk(res, 'inviteWorkspaceUser');
+  }
+
+  async function updateWorkspaceUser(
+    organizationUserId: string,
+    params: UpdateWorkspaceUserParams
+  ): Promise<void> {
+    const res = await auth.authedFetch(`/api/organization-users/${encodeURIComponent(organizationUserId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...(params.firstName !== undefined ? { firstName: params.firstName } : {}),
+        ...(params.lastName !== undefined ? { lastName: params.lastName } : {}),
+        ...(params.role !== undefined ? { role: params.role } : {}),
+        addGroups: params.addGroupIds ?? [],
+        ...(params.userMetadata !== undefined ? { userMetadata: params.userMetadata } : {}),
+      }),
+    });
+    await assertOk(res, 'updateWorkspaceUser');
+  }
+
+  async function setWorkspaceUserArchived(organizationUserId: string, archived: boolean): Promise<void> {
+    const action = archived ? 'archive' : 'unarchive';
+    const res = await auth.authedFetch(
+      `/api/organization-users/${encodeURIComponent(organizationUserId)}/${action}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      }
+    );
+    await assertOk(res, `${action}WorkspaceUser`);
+  }
 
   async function getApp(appId: string): Promise<any> {
     const res = await auth.authedFetch(`/api/apps/${appId}`);
@@ -1980,6 +2093,11 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   return {
     listWorkspaces,
     useWorkspace,
+    listWorkspaceApps,
+    listWorkspaceUsers,
+    inviteWorkspaceUser,
+    updateWorkspaceUser,
+    setWorkspaceUserArchived,
     createApp,
     renameApp,
     getApp,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,6 +60,7 @@ import {
 import { getRuntimeInfoTool } from './getRuntimeInfo.js';
 import { manageThemeTool } from './manageTheme.js';
 import { manageAppPermissionsTool } from './manageAppPermissions.js';
+import { listWorkspaceAppsTool, manageWorkspaceUsersTool } from './workspaceUserManagement.js';
 
 export const LEGACY_SINGULAR_CREATE_TOOL_NAMES = new Set([
   'create_table',
@@ -83,6 +84,8 @@ export function registerTools(
     listWorkspacesTool(client),
     useWorkspaceTool(client),
     manageAppPermissionsTool(client),
+    listWorkspaceAppsTool(client),
+    manageWorkspaceUsersTool(client),
     createAppTool(client),
     getAppSettingsTool(client),
     listAppThemesTool(client),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -60,7 +60,11 @@ import {
 import { getRuntimeInfoTool } from './getRuntimeInfo.js';
 import { manageThemeTool } from './manageTheme.js';
 import { manageAppPermissionsTool } from './manageAppPermissions.js';
-import { listWorkspaceAppsTool, manageWorkspaceUsersTool } from './workspaceUserManagement.js';
+import {
+  listWorkspaceAppsTool,
+  listWorkspaceUsersTool,
+  manageWorkspaceUsersTool,
+} from './workspaceUserManagement.js';
 
 export const LEGACY_SINGULAR_CREATE_TOOL_NAMES = new Set([
   'create_table',
@@ -85,6 +89,7 @@ export function registerTools(
     useWorkspaceTool(client),
     manageAppPermissionsTool(client),
     listWorkspaceAppsTool(client),
+    listWorkspaceUsersTool(client),
     manageWorkspaceUsersTool(client),
     createAppTool(client),
     getAppSettingsTool(client),

--- a/src/tools/workspaceUserManagement.ts
+++ b/src/tools/workspaceUserManagement.ts
@@ -24,12 +24,35 @@ export function listWorkspaceAppsTool(client: ToolJetClient): ToolDef {
   };
 }
 
+export function listWorkspaceUsersTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'list_workspace_users',
+    description:
+      'List users in the workspace pinned to the current ToolJet PAT. Supports pagination, search, and status filtering.',
+    inputSchema: {
+      page: z.number().int().positive().optional(),
+      search_text: z.string().trim().max(100).optional(),
+      filter_status: userStatus.optional(),
+    },
+    async handler(args: { page?: number; search_text?: string; filter_status?: WorkspaceUserStatus }) {
+      try {
+        return ok(
+          await client.listWorkspaceUsers({
+            page: args.page,
+            searchText: args.search_text,
+            status: args.filter_status,
+          })
+        );
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+
 type ManageWorkspaceUsersArgs = {
-  action: 'list' | 'invite' | 'update' | 'archive' | 'unarchive';
+  action: 'invite' | 'update' | 'archive' | 'unarchive';
   organization_user_id?: string;
-  page?: number;
-  search_text?: string;
-  filter_status?: WorkspaceUserStatus;
   email?: string;
   first_name?: string;
   last_name?: string;
@@ -48,15 +71,12 @@ export function manageWorkspaceUsersTool(client: ToolJetClient): ToolDef {
   return {
     name: 'manage_workspace_users',
     description:
-      'List or manage users only in the workspace pinned to the current ToolJet PAT. Invite, update, archive, and ' +
-      'unarchive require confirm:true. Updates can change names/role and add existing custom groups; they cannot ' +
+      'Manage users only in the workspace pinned to the current ToolJet PAT. Invite, update, archive, and unarchive ' +
+      'require confirm:true. Updates can change names/role and add existing custom groups; they cannot ' +
       'remove groups, change passwords, manage other workspaces, or bypass the PAT owner\'s ToolJet permissions.',
     inputSchema: {
-      action: z.enum(['list', 'invite', 'update', 'archive', 'unarchive']),
+      action: z.enum(['invite', 'update', 'archive', 'unarchive']),
       organization_user_id: z.string().uuid().optional(),
-      page: z.number().int().positive().optional(),
-      search_text: z.string().trim().max(100).optional(),
-      filter_status: userStatus.optional(),
       email: z.string().email().optional(),
       first_name: z.string().trim().max(99).optional(),
       last_name: z.string().trim().max(99).optional(),
@@ -67,16 +87,6 @@ export function manageWorkspaceUsersTool(client: ToolJetClient): ToolDef {
     },
     async handler(args: ManageWorkspaceUsersArgs) {
       try {
-        if (args.action === 'list') {
-          return ok(
-            await client.listWorkspaceUsers({
-              page: args.page,
-              searchText: args.search_text,
-              status: args.filter_status,
-            })
-          );
-        }
-
         if (args.confirm !== true) {
           throw new Error(`${args.action} requires confirm:true after checking the exact workspace user.`);
         }

--- a/src/tools/workspaceUserManagement.ts
+++ b/src/tools/workspaceUserManagement.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+import type { ToolJetClient, WorkspaceUserRole, WorkspaceUserStatus } from '../tooljetClient.js';
+import { fail, ok, type ToolDef } from './types.js';
+
+const userRole = z.enum(['admin', 'builder', 'end-user']);
+const userStatus = z.enum(['active', 'archived', 'invited']);
+
+export function listWorkspaceAppsTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'list_workspace_apps',
+    description:
+      'List apps in the workspace pinned to the current ToolJet PAT. This cannot inspect or switch to another workspace.',
+    inputSchema: {
+      page: z.number().int().positive().optional(),
+      search_text: z.string().trim().max(100).optional(),
+    },
+    async handler(args: { page?: number; search_text?: string }) {
+      try {
+        return ok(await client.listWorkspaceApps({ page: args.page, searchText: args.search_text }));
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}
+
+type ManageWorkspaceUsersArgs = {
+  action: 'list' | 'invite' | 'update' | 'archive' | 'unarchive';
+  organization_user_id?: string;
+  page?: number;
+  search_text?: string;
+  filter_status?: WorkspaceUserStatus;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+  role?: WorkspaceUserRole;
+  group_ids?: string[];
+  user_metadata?: Record<string, unknown>;
+  confirm?: boolean;
+};
+
+function required(value: string | undefined, label: string): string {
+  if (!value) throw new Error(`${label} is required for this action.`);
+  return value;
+}
+
+export function manageWorkspaceUsersTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'manage_workspace_users',
+    description:
+      'List or manage users only in the workspace pinned to the current ToolJet PAT. Invite, update, archive, and ' +
+      'unarchive require confirm:true. Updates can change names/role and add existing custom groups; they cannot ' +
+      'remove groups, change passwords, manage other workspaces, or bypass the PAT owner\'s ToolJet permissions.',
+    inputSchema: {
+      action: z.enum(['list', 'invite', 'update', 'archive', 'unarchive']),
+      organization_user_id: z.string().uuid().optional(),
+      page: z.number().int().positive().optional(),
+      search_text: z.string().trim().max(100).optional(),
+      filter_status: userStatus.optional(),
+      email: z.string().email().optional(),
+      first_name: z.string().trim().max(99).optional(),
+      last_name: z.string().trim().max(99).optional(),
+      role: userRole.optional(),
+      group_ids: z.array(z.string().uuid()).max(100).optional(),
+      user_metadata: z.record(z.string(), z.unknown()).optional(),
+      confirm: z.boolean().optional(),
+    },
+    async handler(args: ManageWorkspaceUsersArgs) {
+      try {
+        if (args.action === 'list') {
+          return ok(
+            await client.listWorkspaceUsers({
+              page: args.page,
+              searchText: args.search_text,
+              status: args.filter_status,
+            })
+          );
+        }
+
+        if (args.confirm !== true) {
+          throw new Error(`${args.action} requires confirm:true after checking the exact workspace user.`);
+        }
+
+        if (args.action === 'invite') {
+          await client.inviteWorkspaceUser({
+            email: required(args.email, 'email'),
+            role: args.role ?? 'end-user',
+            firstName: args.first_name,
+            lastName: args.last_name,
+            groupIds: args.group_ids,
+          });
+          return ok({ invited: true, email: args.email });
+        }
+
+        const organizationUserId = required(args.organization_user_id, 'organization_user_id');
+        if (args.action === 'archive' || args.action === 'unarchive') {
+          await client.setWorkspaceUserArchived(organizationUserId, args.action === 'archive');
+          return ok({ organization_user_id: organizationUserId, status: args.action === 'archive' ? 'archived' : 'active' });
+        }
+
+        if (
+          args.first_name === undefined &&
+          args.last_name === undefined &&
+          args.role === undefined &&
+          args.group_ids === undefined &&
+          args.user_metadata === undefined
+        ) {
+          throw new Error('update requires at least one changed field.');
+        }
+        await client.updateWorkspaceUser(organizationUserId, {
+          firstName: args.first_name,
+          lastName: args.last_name,
+          role: args.role,
+          addGroupIds: args.group_ids,
+          userMetadata: args.user_metadata,
+        });
+        return ok({ organization_user_id: organizationUserId, updated: true });
+      } catch (error) {
+        return fail(error);
+      }
+    },
+  };
+}

--- a/tests/tooljetClient.test.ts
+++ b/tests/tooljetClient.test.ts
@@ -1496,4 +1496,38 @@ describe('createClient', () => {
       expect(themes).toEqual([{ id: 'theme1', name: 'ToolJet', definition: {} }]);
     });
   });
+
+  describe('workspace users', () => {
+    it('lists the PAT workspace users with the requested filters', async () => {
+      auth.authedFetch.mockResolvedValueOnce(mockResponse({
+        status: 200,
+        json: { users: [], meta: { total_pages: 1, total_count: 0, current_page: 3 } },
+      }));
+
+      await createClient(auth, config).listWorkspaceUsers({ page: 3, searchText: 'sam', status: 'active' });
+
+      expect(auth.authedFetch).toHaveBeenCalledWith('/api/organization-users?page=3&searchText=sam&status=active');
+    });
+
+    it('updates and archives the exact organization-user id', async () => {
+      auth.authedFetch
+        .mockResolvedValueOnce(mockResponse({ status: 200 }))
+        .mockResolvedValueOnce(mockResponse({ status: 201 }));
+      const client = createClient(auth, config);
+
+      await client.updateWorkspaceUser('org-user-1', { role: 'builder', addGroupIds: ['group-1'] });
+      await client.setWorkspaceUserArchived('org-user-1', true);
+
+      expect(auth.authedFetch).toHaveBeenNthCalledWith(1, '/api/organization-users/org-user-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: 'builder', addGroups: ['group-1'] }),
+      });
+      expect(auth.authedFetch).toHaveBeenNthCalledWith(2, '/api/organization-users/org-user-1/archive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+    });
+  });
 });

--- a/tests/workspaceUserManagement.test.ts
+++ b/tests/workspaceUserManagement.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolJetClient } from '../src/tooljetClient.js';
+import {
+  listWorkspaceAppsTool,
+  listWorkspaceUsersTool,
+  manageWorkspaceUsersTool,
+} from '../src/tools/workspaceUserManagement.js';
+
+function client() {
+  return {
+    listWorkspaceApps: vi.fn(),
+    listWorkspaceUsers: vi.fn(),
+    inviteWorkspaceUser: vi.fn(),
+    updateWorkspaceUser: vi.fn(),
+    setWorkspaceUserArchived: vi.fn(),
+  };
+}
+
+function body(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe('workspace management tools', () => {
+  it('forwards bounded app and user listing filters', async () => {
+    const mock = client();
+    mock.listWorkspaceApps.mockResolvedValue({ apps: [] });
+    mock.listWorkspaceUsers.mockResolvedValue({ users: [], meta: { total_pages: 1, total_count: 0, current_page: 2 } });
+
+    await listWorkspaceAppsTool(mock as unknown as ToolJetClient).handler({ page: 2, search_text: 'orders' });
+    const result = await listWorkspaceUsersTool(mock as unknown as ToolJetClient).handler({
+      page: 2,
+      search_text: 'sam',
+      filter_status: 'active',
+    });
+
+    expect(mock.listWorkspaceApps).toHaveBeenCalledWith({ page: 2, searchText: 'orders' });
+    expect(mock.listWorkspaceUsers).toHaveBeenCalledWith({ page: 2, searchText: 'sam', status: 'active' });
+    expect(body(result)).toMatchObject({ users: [] });
+  });
+
+  it('refuses every workspace-user mutation without explicit confirmation', async () => {
+    const mock = client();
+    const result = await manageWorkspaceUsersTool(mock as unknown as ToolJetClient).handler({
+      action: 'update',
+      organization_user_id: '00000000-0000-4000-8000-000000000001',
+      role: 'admin',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/confirm:true/);
+    expect(mock.updateWorkspaceUser).not.toHaveBeenCalled();
+  });
+
+  it('applies an approved role update to the exact organization user', async () => {
+    const mock = client();
+    mock.updateWorkspaceUser.mockResolvedValue(undefined);
+    const id = '00000000-0000-4000-8000-000000000001';
+    const result = await manageWorkspaceUsersTool(mock as unknown as ToolJetClient).handler({
+      action: 'update',
+      organization_user_id: id,
+      role: 'builder',
+      group_ids: [],
+      confirm: true,
+    });
+
+    expect(mock.updateWorkspaceUser).toHaveBeenCalledWith(id, {
+      firstName: undefined,
+      lastName: undefined,
+      role: 'builder',
+      addGroupIds: [],
+      userMetadata: undefined,
+    });
+    expect(body(result)).toEqual({ organization_user_id: id, updated: true });
+  });
+
+  it('archives only the requested organization user after confirmation', async () => {
+    const mock = client();
+    mock.setWorkspaceUserArchived.mockResolvedValue(undefined);
+    const id = '00000000-0000-4000-8000-000000000001';
+
+    await manageWorkspaceUsersTool(mock as unknown as ToolJetClient).handler({
+      action: 'archive',
+      organization_user_id: id,
+      confirm: true,
+    });
+
+    expect(mock.setWorkspaceUserArchived).toHaveBeenCalledWith(id, true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add list_workspace_apps for apps in the PAT-pinned workspace.
- Add the read-only list_workspace_users tool with pagination, search, and status filtering.
- Add manage_workspace_users with invite, update, archive, and unarchive actions.
- Require confirm:true for every user mutation and validate exact ids, roles, email addresses, and group ids.
- Use only PAT session authentication; the old external access token is not required.
- Keep all operations confined to the PAT workspace and the PAT owner's ToolJet permissions.

## Available MCP tools

### list_workspace_apps

- List front-end apps in the workspace pinned to the current PAT.
- Search apps by name using search_text.
- Paginate results using page.
- Cannot inspect or switch to another workspace.

### list_workspace_users

- Read-only listing of users in the PAT-pinned workspace.
- Search by email or name using search_text.
- Filter by active, invited, or archived status using filter_status.
- Paginate with page; responses include pagination metadata so an agent can retrieve every page when asked for all users.

### manage_workspace_users

Supported mutation actions:

- invite: invite a user with an email, role (admin, builder, or end-user), optional first and last name, and optional existing group ids.
- update: change first name, last name, role, user metadata, or add the user to existing groups.
- archive: archive the exact organization_user_id.
- unarchive: unarchive the exact organization_user_id.

Every mutation requires confirm:true. The tool cannot remove groups, change passwords, access another workspace, or bypass the PAT owner's ToolJet permissions.

## Testing

- npm build and plugin bundle build passed.
- Full MCP test suite passed: 577 tests across 37 files.
- Real MCP stdio test passed for tool discovery, app listing, user listing, invite, update, archive, unarchive, and cleanup.
- Actual Grok chat using the default core profile successfully handled: List all the users in my current ToolJet workspace. Do not modify any user.
- The read-only run called list_workspace_users and did not expose or call manage_workspace_users.

## Impact

- Speed: each action maps directly to one existing ToolJet API request; no extra discovery round trip is added beyond requested pagination.
- Quality: separating reads from mutations gives read-only conversations deterministic access to user listing while keeping mutations behind confirmation and ToolJet permissions.
- Token usage: three concise tool schemas add a small cached prompt overhead only for agents that expose them; API responses remain paginated and searchable.

Depends on ToolJet/ToolJet#17723.
