### PR TITLE
Fix oversized generated single-line inputs

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -512,6 +512,33 @@ export function renderedHeight(component: LintComponent, rect?: Rect): number {
   return authored + (hasRenderedLabel ? TOP_ALIGNMENT_HEIGHT_INCREMENT : 0);
 }
 
+/** Standard single-line form controls keep their catalog-default authored height. Making the
+ *  component taller does not enlarge its value text; with a top-aligned label ToolJet adds a
+ *  separate 20px rendered footprint outside that authored box. Treat the catalog's
+ *  compactFormHeight hint as the source-of-truth marker instead of duplicating a component list. */
+function lintStandardSingleLineInputHeight(component: LintComponent): string[] {
+  const schema = component.type ? getComponentSchema(component.type) : undefined;
+  const defaultHeight = schema?.defaultSize?.height;
+  if (!schema?.renderingHints?.compactFormHeight || defaultHeight === undefined) return [];
+
+  const layouts: Array<[string, Rect]> = [];
+  if (component.layout) layouts.push(['layout', component.layout]);
+  if (component.layouts?.desktop) layouts.push(['desktop', component.layouts.desktop]);
+  if (component.layouts?.mobile) layouts.push(['mobile', component.layouts.mobile]);
+
+  const label = component.name ?? component.type ?? 'component';
+  return layouts.flatMap(([layoutName, layout]) => {
+    const authoredHeight = layout.height;
+    if (authoredHeight === undefined || authoredHeight <= defaultHeight) return [];
+    return [
+      `${component.type} "${label}": ${layoutName} authored height ${authoredHeight}px exceeds the standard ` +
+        `single-line height ${defaultHeight}px. Oversizing does not enlarge the value text. Keep height at ` +
+        `${defaultHeight}px; a top-aligned label renders ${TOP_ALIGNMENT_HEIGHT_INCREMENT}px outside the authored ` +
+        `box, so move the following row down instead of increasing this field's height.`,
+    ];
+  });
+}
+
 /** Text renders inside 4px of canvas-wrapper padding plus its own 1px top/bottom border. A single
  * line therefore needs fontSize * lineHeight + 6 authored pixels or descenders are clipped. */
 export function minimumTextHeight(component: LintComponent): number | undefined {
@@ -1636,6 +1663,7 @@ export function lintComponents(components: LintComponent[]): LintResult {
   for (const c of components) {
     const r = lintComponentSpec(c);
     errors.push(...r.errors);
+    errors.push(...lintStandardSingleLineInputHeight(c));
     warnings.push(...r.warnings);
   }
   errors.push(...lintComponentSlots(components));

--- a/tests/appPhaseTools.test.ts
+++ b/tests/appPhaseTools.test.ts
@@ -23,7 +23,7 @@ describe('plan token + apply_app_phase', () => {
       {
         id: 'title-id', name: 'caseTitle', type: 'TextInput',
         properties: { label: { value: 'Title' } }, styles: { alignment: { value: 'top' } },
-        layouts: { desktop: { top: 20, left: 2, width: 20, height: 60 } },
+        layouts: { desktop: { top: 20, left: 2, width: 20, height: 40 } },
       },
       {
         id: 'save-id', name: 'saveCase', type: 'Button',
@@ -102,7 +102,7 @@ describe('plan token + apply_app_phase', () => {
       pages: [{
         client_ref: 'home', name: 'Overview', icon: 'IconLayoutDashboard',
         components: [
-          { client_ref: 'title', name: 'caseTitle', type: 'TextInput', properties: { label: 'Title' }, styles: { alignment: 'top' }, layout: { top: 20, left: 2, width: 20, height: 60 } },
+          { client_ref: 'title', name: 'caseTitle', type: 'TextInput', properties: { label: 'Title' }, styles: { alignment: 'top' }, layout: { top: 20, left: 2, width: 20, height: 40 } },
           { client_ref: 'save', name: 'saveCase', type: 'Button', properties: { text: 'Save' }, layout: { top: 120, left: 2, width: 6, height: 40 } },
         ],
       }],

--- a/tests/appSpecLint.test.ts
+++ b/tests/appSpecLint.test.ts
@@ -31,7 +31,7 @@ describe('lint_app_spec', () => {
           {
             client_ref: 'caseTitle', name: 'caseTitle', type: 'TextInput',
             properties: { label: { value: 'Title' } }, styles: { alignment: { value: 'top' } },
-            layout: { top: 20, left: 2, width: 20, height: 60 },
+            layout: { top: 20, left: 2, width: 20, height: 40 },
           },
           {
             client_ref: 'save', name: 'saveCase', type: 'Button', properties: { text: { value: 'Save' } },
@@ -53,6 +53,36 @@ describe('lint_app_spec', () => {
     expect(body.counts).toMatchObject({ tables: 1, seed_rows: 0, pages: 1, components: 2, queries: 2, events: 5, lifecycles: 1 });
     expect(body.plan_token).toEqual(expect.any(String));
     expect(client.listDatasources).toHaveBeenCalledOnce();
+  });
+
+  it('blocks oversized standard single-line fields before issuing a plan token', async () => {
+    const client = {
+      listDatasources: vi.fn().mockResolvedValue([]),
+      listTables: vi.fn().mockResolvedValue([]),
+    } as unknown as ToolJetClient;
+    const result = await lintAppSpecTool(client).handler({
+      pages: [{
+        name: 'Log Bug', icon: 'IconBug',
+        components: [
+          {
+            client_ref: 'title', name: 'bugTitle', type: 'TextInput',
+            properties: { label: 'Title' }, styles: { alignment: 'top' },
+            layout: { top: 100, left: 2, width: 39, height: 90 },
+          },
+          {
+            client_ref: 'module', name: 'bugModule', type: 'DropdownV2',
+            properties: { label: 'Module' }, styles: { alignment: 'top' },
+            layout: { top: 220, left: 2, width: 18, height: 90 },
+          },
+        ],
+      }],
+    });
+
+    const body = textOf(result);
+    expect(body.ok).toBe(false);
+    expect(body.plan_token).toBeUndefined();
+    expect(body.errors.join(' ')).toMatch(/TextInput "bugTitle".*90px.*40px/is);
+    expect(body.errors.join(' ')).toMatch(/DropdownV2 "bugModule".*90px.*40px/is);
   });
 
   it('uses existing app context for repair bindings and event targets', async () => {

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1107,6 +1107,31 @@ describe('lintOperationalViewport', () => {
 });
 
 describe('lintComponents (batch)', () => {
+  it.each(['TextInput', 'DropdownV2'])(
+    'blocks an oversized standard single-line %s and explains top-label spacing',
+    (type) => {
+      const result = lintComponents([{
+        name: 'bugTitle',
+        type,
+        styles: { alignment: { value: 'top' } },
+        layout: { top: 100, left: 2, width: 20, height: 90 },
+      }]);
+
+      expect(result.errors.join(' ')).toMatch(
+        /authored height 90px exceeds the standard single-line height 40px.*does not enlarge the value text.*top-aligned label renders 20px outside.*move the following row down/is
+      );
+  });
+
+  it('accepts catalog-default single-line heights and does not restrict multiline TextArea height', () => {
+    const result = lintComponents([
+      { name: 'title', type: 'TextInput', layout: { top: 0, left: 0, width: 20, height: 40 } },
+      { name: 'status', type: 'DropdownV2', layout: { top: 70, left: 0, width: 20, height: 40 } },
+      { name: 'description', type: 'TextArea', layout: { top: 140, left: 0, width: 20, height: 180 } },
+    ]);
+
+    expect(result.errors).toEqual([]);
+  });
+
   it('blocks named slots on component types that do not expose native regions', () => {
     const result = lintComponents([
       { name: 'board', type: 'Kanban', clientRef: 'board' },


### PR DESCRIPTION
## Summary
- reject authored heights above the catalog default for standard single-line inputs
- explain that labels and longer values do not require increasing the input control height
- cover desktop/mobile layouts and app-spec/app-phase lint paths

## Tests
- `npm test -- tests/lint.test.ts tests/appSpecLint.test.ts tests/appPhaseTools.test.ts` (98 passed)