### PR TITLE
Block unusably short Table layouts

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1240,7 +1240,14 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
         TABLE_FOOTER_HEIGHT_PX +
         TABLE_BORDER_PX;
       const minimumHeight = chromeHeight + rowsPerPage * rowHeight;
-      if (desktopHeight < minimumHeight) {
+      const minimumUsableHeight = chromeHeight + rowHeight;
+      if (desktopHeight < minimumUsableHeight) {
+        warnings.push(
+          `Table "${label}": desktop height ${desktopHeight}px cannot show even one data row below its ` +
+            `${toolbarVisible ? 'toolbar, ' : ''}header, and footer; use at least ${minimumUsableHeight}px, ` +
+            'reduce the Table chrome, or enable dynamicHeight. The Table body is effectively unusable.'
+        );
+      } else if (desktopHeight < minimumHeight) {
         warnings.push(
           `Table "${label}": desktop height ${desktopHeight}px is too short to show ${rowsPerPage} ` +
             `${cellSize === 'condensed' ? 'condensed' : 'regular'} rows without an inner scrollbar; use about ` +

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -689,6 +689,17 @@ describe('lintComponentSpec', () => {
   });
 
   it('warns when a static-height Table cannot show rowsPerPage without inner scrolling', () => {
+    const unusable = lintComponentSpec({
+      name: 'deployments',
+      type: 'Table',
+      properties: { rowsPerPage: { value: '{{10}}' } },
+      styles: { cellSize: { value: 'regular' } },
+      layout: { top: 0, left: 0, width: 30, height: 62 },
+    });
+    expect(unusable.warnings.join(' ')).toMatch(
+      /height 62px.*cannot show even one data row.*at least 200px.*effectively unusable/i
+    );
+
     const compact = lintComponentSpec({
       name: 'orders',
       type: 'Table',
@@ -697,6 +708,7 @@ describe('lintComponentSpec', () => {
       layout: { top: 0, left: 0, width: 30, height: 460 },
     });
     expect(compact.warnings.join(' ')).toMatch(/height 460px.*10 regular rows.*inner scrollbar.*about 614px/i);
+    expect(compact.warnings.join(' ')).not.toMatch(/cannot show even one data row|effectively unusable/i);
 
     const tall = lintComponentSpec({
       name: 'orders',


### PR DESCRIPTION
## Summary
- emit a distinct severe warning when a Table has no room for even one data row
- keep ordinary compact, internally scrollable Tables as non-blocking warnings
- add regression coverage for unusable and compact layouts

## Verification
- focused lint suite: 88 passed
- full suite: 665 passed, 3 pre-existing unrelated tool-annotation failures
- TypeScript build retains 4 pre-existing ToolDef annotation errors