### PR TITLE
Combine geometry lint and datasource detection fixes

### DIFF
--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1240,7 +1240,14 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
         TABLE_FOOTER_HEIGHT_PX +
         TABLE_BORDER_PX;
       const minimumHeight = chromeHeight + rowsPerPage * rowHeight;
-      if (desktopHeight < minimumHeight) {
+      const minimumUsableHeight = chromeHeight + rowHeight;
+      if (desktopHeight < minimumUsableHeight) {
+        warnings.push(
+          `Table "${label}": desktop height ${desktopHeight}px cannot show even one data row below its ` +
+            `${toolbarVisible ? 'toolbar, ' : ''}header, and footer; use at least ${minimumUsableHeight}px, ` +
+            'reduce the Table chrome, or enable dynamicHeight. The Table body is effectively unusable.'
+        );
+      } else if (desktopHeight < minimumHeight) {
         warnings.push(
           `Table "${label}": desktop height ${desktopHeight}px is too short to show ${rowsPerPage} ` +
             `${cellSize === 'condensed' ? 'condensed' : 'regular'} rows without an inner scrollbar; use about ` +

--- a/src/queryExecutionSafety.ts
+++ b/src/queryExecutionSafety.ts
@@ -166,6 +166,67 @@ function assessRestGet(options: Record<string, unknown>, datasourceId?: string):
   };
 }
 
+/** Supabase's API plugin uses operation-specific table/limit fields rather than SQL. Treat its
+ *  row reads like other remote APIs: statically classify them as reads, but require explicit user
+ *  approval before crossing into the remote system. Writes remain fail-closed. */
+function assessSupabase(options: Record<string, unknown>, datasourceId?: string): QueryReadAssessment {
+  const identity = { datasourceKind: 'supabase', ...(datasourceId ? { datasourceId } : {}) };
+  const operation = typeof options.operation === 'string' ? options.operation.toLowerCase() : undefined;
+  const refuse = (reason: string): QueryReadAssessment => ({
+    provenRead: false, directSafe: false, countOnly: false, selectStar: false,
+    requiresCountPreflight: false, reason, ...identity,
+  });
+  if (!operation) return refuse('Supabase query has no operation.');
+
+  if (operation === 'count_rows') {
+    const table = typeof options.count_table_name === 'string' ? options.count_table_name.trim() : '';
+    if (!table || containsBinding(table)) {
+      return refuse('Supabase count_rows requires a non-empty static count_table_name.');
+    }
+    const filters = options.count_filters;
+    const fullSourceCount = filters === undefined || filters === null || filters === '' ||
+      (Array.isArray(filters) && filters.length === 0) ||
+      (!!record(filters) && Object.keys(record(filters)!).length === 0);
+    return {
+      provenRead: true, directSafe: false, countOnly: true, selectStar: false,
+      requiresCountPreflight: false, requiresRemoteReadConfirmation: true,
+      fullSourceCount, simpleSourceRead: true,
+      source: { kind: 'remote_endpoint', value: `supabase:${table.toLowerCase()}` },
+      maxRows: 1,
+      reason: 'Supabase count_rows reads a remote project and may consume API quota.',
+      ...identity,
+    };
+  }
+
+  if (operation !== 'get_rows') {
+    return refuse(`Supabase operation ${operation} is not a read; it can change Supabase data.`);
+  }
+  const table = typeof options.get_table_name === 'string' ? options.get_table_name.trim() : '';
+  if (!table || containsBinding(table)) {
+    return refuse('Supabase get_rows requires a non-empty static get_table_name.');
+  }
+  const maxRows = staticPositiveInteger(options.get_limit);
+  const remote = {
+    provenRead: true as const, directSafe: false as const, countOnly: false as const,
+    selectStar: false as const, requiresRemoteReadConfirmation: true as const,
+    simpleSourceRead: true as const,
+    source: { kind: 'remote_endpoint' as const, value: `supabase:${table.toLowerCase()}` },
+    ...identity,
+  };
+  if (maxRows !== undefined && maxRows <= LARGE_READ_ROW_THRESHOLD) {
+    return {
+      ...remote, requiresCountPreflight: false, maxRows,
+      reason: 'Supabase get_rows reads a remote project and may consume API quota.',
+    };
+  }
+  return {
+    ...remote, requiresCountPreflight: true, maxRows,
+    reason: maxRows === undefined
+      ? 'Supabase get_rows has no static get_limit.'
+      : `Supabase get_rows can return up to ${maxRows} rows, above the ${LARGE_READ_ROW_THRESHOLD}-row safety threshold.`,
+  };
+}
+
 function stripSql(sql: string): string {
   return sql.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '').trim().replace(/;\s*$/, '').trim();
 }
@@ -363,6 +424,8 @@ export function assessQueryRead(query: QuerySummary): QueryReadAssessment {
   if (kind === 'restapi') return assessRestGet(options, datasourceId);
 
   if (kind === 'servicenow') return assessServiceNow(options, datasourceId);
+
+  if (kind === 'supabase') return assessSupabase(options, datasourceId);
 
   if (kind === 'tooljetdb') {
     if (operation === 'list_rows') return assessListRows(kind, options, datasourceId);

--- a/src/tools/runQuery.ts
+++ b/src/tools/runQuery.ts
@@ -190,8 +190,9 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
       `observed count is larger, retry only after explicit user approval with user_confirmed_large_read:true. ` +
       'BigQuery, Snowflake, and Redshift reads also require explicit cost approval with ' +
       'user_confirmed_billable_read:true, even when row-limited. Never set confirmation flags from inferred consent. ' +
-      'A static REST GET requires separate approval with user_confirmed_remote_read:true because it may expose sensitive ' +
-      'data, consume quota, or return an unbounded payload; REST writes and binding-dependent requests are always refused. ' +
+      'Static remote reads (including REST GET and Supabase get_rows/count_rows) require separate approval with ' +
+      'user_confirmed_remote_read:true because they may expose sensitive data or consume quota; remote writes and ' +
+      'binding-dependent requests are always refused. ' +
       'If saved options reference `components.*`, the result ' +
       'includes a warning because browser-free execution cannot prove the component-resolved pagination/filter behavior.',
     inputSchema: {
@@ -229,15 +230,17 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
 
         if (assessment.requiresRemoteReadConfirmation && !args.user_confirmed_remote_read) {
           return fail(new Error(
-            `run_query refused REST GET "${query.name ?? query.id}" before execution: remote reads can expose sensitive ` +
+            `run_query refused remote ${query.kind ?? 'datasource'} read "${query.name ?? query.id}" before execution: ` +
+              'remote reads can expose sensitive ' +
               'data, consume API quota, and return an unbounded payload. Tell the user which saved query will run and ask ' +
               'explicitly; retry with user_confirmed_remote_read:true only after they approve that request.'
           ));
         }
         if (assessment.requiresRemoteReadConfirmation) {
-          warnings.push(
-            'User-confirmed REST GET: the remote API controls response size and quota. Inspect metadata.request and metadata.response, and add API-specific pagination before another run when needed.'
-          );
+          warnings.push(assessment.datasourceKind === 'restapi'
+            ? 'User-confirmed REST GET: the remote API controls response size and quota. Inspect metadata.request and metadata.response, and add API-specific pagination before another run when needed.'
+            : `User-confirmed remote ${query.kind ?? 'datasource'} read: the remote system controls response size and quota. ` +
+              'Inspect returned metadata when available, and add datasource-specific pagination before another run when needed.');
         }
 
         if (assessment.requiresBillableReadConfirmation && !args.user_confirmed_billable_read) {

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -12,6 +12,70 @@ import { getDatasourceQuerySchema } from '../datasourceCatalog.js';
  */
 const NOT_IMPLEMENTED = /testconnection method not implemented/i;
 
+/** ToolJet plugins flatten every negative test result into status:'failed', including validation
+ *  errors and probes that require a table/resource. Only messages that explicitly prove the stored
+ *  connection cannot reach or authenticate to the service may mark a datasource unhealthy. Unknown
+ *  failures stay inconclusive and are verified through a separately approved bounded read. */
+const EXPLICIT_CONNECTIVITY_FAILURE = new RegExp([
+  'connection (?:was )?refused', 'econnrefused',
+  '(?:could not|cannot|unable to|failed to) connect',
+  'connection (?:timed out|timeout|terminated|closed)', 'etimedout',
+  'network (?:is )?unreachable', 'enetunreach', 'ehostunreach',
+  'getaddrinfo', 'enotfound', 'dns (?:lookup )?failed', 'host(?:name)? (?:was )?not found',
+  'authentication (?:failed|error)', 'authorization (?:failed|error)',
+  'invalid (?:credentials|password|api[ -]?key|access token|refresh token)',
+  'login failed', 'unauthorized', 'access denied',
+  '(?:credentials|password|api[ -]?key|access token|refresh token|certificate) (?:has |have )?expired',
+  'ssl (?:error|failure)', 'tls (?:error|failure)', 'certificate (?:error|invalid|untrusted)',
+  'free trial (?:has )?ended', 'warehouse(?:s)? (?:has |have )?been suspended',
+  'account (?:is |has been )?suspended', 'billing (?:is )?disabled',
+].join('|'), 'i');
+
+function isExplicitConnectivityFailure(message: string | undefined): boolean {
+  return !!message && EXPLICIT_CONNECTIVITY_FAILURE.test(message);
+}
+
+function inconclusiveResult(
+  header: Record<string, unknown>,
+  message: string | undefined
+): ReturnType<typeof ok> {
+  const detail = message?.trim();
+  return ok({
+    ...header,
+    supported: true,
+    status: 'inconclusive',
+    message:
+      'The datasource connection test did not prove that the connection is broken' +
+      (detail ? ` (${detail})` : '') +
+      '. Do not replace the requested datasource. Ask the user for permission, then verify it with a small, ' +
+      'bounded read against the actual table or resource.',
+    verification: {
+      action: 'ask_then_run_bounded_read',
+      requires_user_approval: true,
+      instruction:
+        'Name the saved query and target table/resource when asking. Permission to verify does not grant ' +
+        'permission to substitute another datasource.',
+    },
+  });
+}
+
+function failedResult(header: Record<string, unknown>, message: string): ReturnType<typeof ok> {
+  const settingsUrl = typeof header.settings_url === 'string' ? header.settings_url : undefined;
+  return ok({
+    ...header,
+    supported: true,
+    status: 'failed',
+    message: message.trim(),
+    recovery: {
+      action: 'open_datasource_settings',
+      ...(settingsUrl ? { url: settingsUrl } : {}),
+      instruction:
+        'Ask the user to repair this connection in ToolJet. Never enter credentials, authorize ' +
+        'OAuth, or save settings on their behalf.',
+    },
+  });
+}
+
 /** Identical whether the catalog pre-empted the call or ToolJet answered it, so the model cannot
  *  tell the two paths apart and cannot come to depend on the difference. */
 function unsupportedMessage(kind: string): string {
@@ -44,15 +108,18 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
       "Run ToolJet's own connection test for one ALREADY-CONNECTED datasource — the same check the " +
       'datasource settings page performs. Uses the datasource\'s stored credentials; you never supply, ' +
       'see, or need them. Use it to distinguish a broken connection from a wrong query when a run fails, ' +
-      'or to confirm a source before building on it. Returns supported:false for datasource kinds whose ' +
-      'plugin does not implement a connection test (REST API, GraphQL, and most OAuth/HTTP integrations) — ' +
-      'that is not a fault and says nothing about the connection. On a real failure, hand the returned ' +
+      'or to confirm a source before building on it. The result is tri-state: ok, failed only for an explicit ' +
+      'connectivity/authentication failure, or inconclusive for plugin validation, missing-resource, and ' +
+      'ambiguous failures. Inconclusive never means broken and must be verified with a separately approved ' +
+      'bounded read. Returns supported:false when the plugin has no connection test at all. On a real failure, hand the returned ' +
       'settings_url to the user for repair; never enter credentials or save settings for them.',
     inputSchema: {
       version_id: z.string().min(1),
       datasource_id: z.string().min(1),
     },
     async handler(args: { version_id: string; datasource_id: string }) {
+      let datasourceResolved = false;
+      let header: Record<string, unknown> = { datasource: { id: args.datasource_id } };
       try {
         const datasource = (await client.listDatasources(args.version_id)).find(
           (candidate) => candidate.id === args.datasource_id
@@ -62,7 +129,8 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
             new Error(`Datasource "${args.datasource_id}" is not available on version "${args.version_id}".`)
           );
         }
-        const header = {
+        datasourceResolved = true;
+        header = {
           datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind },
           settings_url: datasource.settings_url,
         };
@@ -100,26 +168,17 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         if (result.status === 'ok') {
           return ok({ ...header, supported: true, status: 'ok' });
         }
-        return ok({
-          ...header,
-          supported: true,
-          status: 'failed',
-          ...(message ? { message: message.trim() } : {}),
-          recovery: {
-            action: 'open_datasource_settings',
-            url: datasource.settings_url,
-            instruction:
-              'Ask the user to repair this connection in ToolJet. Never enter credentials, authorize ' +
-              'OAuth, or save settings on their behalf.',
-          },
-        });
+        if (!isExplicitConnectivityFailure(message)) {
+          return inconclusiveResult(header, message);
+        }
+        return failedResult(header, message!);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         // A permission denial is about the caller, not the datasource. Returned as a normal result
         // so the model reports it accurately instead of announcing a broken source.
         if (isForbidden(message)) {
           return ok({
-            datasource: { id: args.datasource_id },
+            ...header,
             supported: true,
             status: 'not_permitted',
             message:
@@ -128,15 +187,22 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
               'The connection itself was not tested.',
           });
         }
+        // Failure before listDatasources positively resolved the target is an MCP/ToolJet discovery
+        // error, not a plugin verdict. Keep it as a tool error so infrastructure failures are visible.
+        if (!datasourceResolved) return fail(err);
         if (isNotFound(message)) {
-          return fail(
-            new Error(
-              `ToolJet has no test-connection endpoint or no datasource "${args.datasource_id}" for this ` +
-                `environment (${message}).`
-            )
-          );
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message:
+              `ToolJet has no datasource-level test endpoint for this connected source (${message}). ` +
+              'This says nothing about its health; verify it with a separately approved bounded read.',
+          });
         }
-        return fail(err);
+        return isExplicitConnectivityFailure(message)
+          ? failedResult(header, message)
+          : inconclusiveResult(header, message);
       }
     },
   };

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -689,6 +689,17 @@ describe('lintComponentSpec', () => {
   });
 
   it('warns when a static-height Table cannot show rowsPerPage without inner scrolling', () => {
+    const unusable = lintComponentSpec({
+      name: 'deployments',
+      type: 'Table',
+      properties: { rowsPerPage: { value: '{{10}}' } },
+      styles: { cellSize: { value: 'regular' } },
+      layout: { top: 0, left: 0, width: 30, height: 62 },
+    });
+    expect(unusable.warnings.join(' ')).toMatch(
+      /height 62px.*cannot show even one data row.*at least 200px.*effectively unusable/i
+    );
+
     const compact = lintComponentSpec({
       name: 'orders',
       type: 'Table',
@@ -697,6 +708,7 @@ describe('lintComponentSpec', () => {
       layout: { top: 0, left: 0, width: 30, height: 460 },
     });
     expect(compact.warnings.join(' ')).toMatch(/height 460px.*10 regular rows.*inner scrollbar.*about 614px/i);
+    expect(compact.warnings.join(' ')).not.toMatch(/cannot show even one data row|effectively unusable/i);
 
     const tall = lintComponentSpec({
       name: 'orders',

--- a/tests/queryExecutionSafety.test.ts
+++ b/tests/queryExecutionSafety.test.ts
@@ -142,6 +142,41 @@ describe('query execution safety', () => {
     })).toMatchObject({ provenRead: false, directSafe: false });
   });
 
+  it('classifies bounded Supabase reads instead of treating the datasource as unknown', () => {
+    expect(assessQueryRead({
+      id: 'supa-rows', kind: 'supabase', data_source_id: 'supa-main',
+      options: { operation: 'get_rows', get_table_name: 'deployments', get_limit: '200' },
+    })).toMatchObject({
+      provenRead: true,
+      directSafe: false,
+      requiresCountPreflight: false,
+      requiresRemoteReadConfirmation: true,
+      maxRows: 200,
+      source: { kind: 'remote_endpoint', value: 'supabase:deployments' },
+    });
+    expect(assessQueryRead({
+      id: 'supa-count', kind: 'supabase', data_source_id: 'supa-main',
+      options: { operation: 'count_rows', count_table_name: 'deployments', count_filters: [] },
+    })).toMatchObject({
+      provenRead: true, countOnly: true, fullSourceCount: true, maxRows: 1,
+      requiresRemoteReadConfirmation: true,
+    });
+  });
+
+  it('refuses Supabase writes and dynamic or missing relations', () => {
+    for (const operation of ['create_row', 'update_row', 'delete_row']) {
+      expect(assessQueryRead({ id: operation, kind: 'supabase', options: { operation } }))
+        .toMatchObject({ provenRead: false, directSafe: false });
+    }
+    expect(assessQueryRead({
+      id: 'dynamic', kind: 'supabase',
+      options: { operation: 'get_rows', get_table_name: '{{components.table.value}}', get_limit: 10 },
+    })).toMatchObject({ provenRead: false, directSafe: false });
+    expect(assessQueryRead({
+      id: 'missing', kind: 'supabase', options: { operation: 'get_rows', get_limit: 10 },
+    })).toMatchObject({ provenRead: false, directSafe: false });
+  });
+
   it('extracts only an unambiguous one-row numeric count', () => {
     expect(extractRowCount({ status: 'ok', data: [{ total: '2400' }] })).toBe(2400);
     expect(extractRowCount({ status: 'ok', data: [{ total: 20, other: 2 }] })).toBeUndefined();

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -78,6 +78,121 @@ describe('test_datasource_connection tool', () => {
     });
   });
 
+  it('does not report Supabase as broken when its relation-scoped probe has no table', async () => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockResolvedValue([
+        { id: 'supa1', name: 'Production Supabase', kind: 'supabase', settings_url: 'http://tj/ws/data-sources/supa1' },
+      ]),
+      getDatasourceConnectionDetails: vi.fn().mockResolvedValue({
+        kind: 'supabase', pluginId: '11111111-1111-1111-1111-111111111111', options: { url: 'stored' },
+      }),
+      testDatasourceConnection: vi.fn().mockResolvedValue({
+        status: 'failed', message: 'Invalid relation name: relation must be a non-empty string',
+      }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'supa1' })
+    );
+    expect(parsed).toMatchObject({
+      status: 'inconclusive',
+      supported: true,
+      datasource: { kind: 'supabase' },
+      verification: { action: 'ask_then_run_bounded_read', requires_user_approval: true },
+    });
+    expect(parsed.message).toMatch(/did not prove.*broken.*small.*bounded read/i);
+    expect(parsed.recovery).toBeUndefined();
+  });
+
+  it.each([
+    ['mongodb', 'Invalid collection name: collection must be a non-empty string'],
+    ['postgresql', 'Table name is required before this test can run'],
+    ['mysql', 'Plugin validation failed for field database_name'],
+    ['snowflake', 'An unexpected plugin error occurred'],
+  ])('treats ambiguous %s plugin failures as inconclusive', async (kind, message) => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockResolvedValue([
+        { id: 'source1', name: 'Requested source', kind, settings_url: 'http://tj/ws/data-sources/source1' },
+      ]),
+      getDatasourceConnectionDetails: vi.fn().mockResolvedValue({ kind, options: {} }),
+      testDatasourceConnection: vi.fn().mockResolvedValue({ status: 'failed', message }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'source1' })
+    );
+    expect(parsed).toMatchObject({
+      status: 'inconclusive',
+      supported: true,
+      datasource: { kind },
+      verification: { requires_user_approval: true },
+    });
+    expect(parsed.message).toContain(message);
+    expect(parsed.recovery).toBeUndefined();
+  });
+
+  it.each([
+    'authentication failed: invalid credentials',
+    'connection timed out while reaching the host',
+    'Your free trial has ended and all of your virtual warehouses have been suspended',
+  ])('keeps explicit connectivity failures actionable: %s', async (message) => {
+    const client = clientWith({
+      testDatasourceConnection: vi.fn().mockResolvedValue({ status: 'failed', message }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed).toMatchObject({ status: 'failed', supported: true, recovery: { action: 'open_datasource_settings' } });
+    expect(parsed.verification).toBeUndefined();
+  });
+
+  it('does not invent a broken connection when the plugin returns no reason', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi.fn().mockResolvedValue({ status: 'failed' }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed).toMatchObject({ status: 'inconclusive', verification: { requires_user_approval: true } });
+  });
+
+  it('applies the same tri-state rules when the plugin throws instead of returning failed', async () => {
+    const ambiguousClient = clientWith({
+      testDatasourceConnection: vi.fn().mockRejectedValue(new Error('Relation name must be provided')),
+    });
+    const ambiguous = textOf(
+      await testDatasourceConnectionTool(ambiguousClient).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(ambiguous).toMatchObject({ status: 'inconclusive', verification: { requires_user_approval: true } });
+
+    const unreachableClient = clientWith({
+      testDatasourceConnection: vi.fn().mockRejectedValue(new Error('ECONNREFUSED database.internal:5432')),
+    });
+    const unreachable = textOf(
+      await testDatasourceConnectionTool(unreachableClient).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(unreachable).toMatchObject({ status: 'failed', recovery: { action: 'open_datasource_settings' } });
+  });
+
+  it('treats a missing test endpoint as unsupported after the datasource was discovered', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi.fn().mockRejectedValue(
+        new Error('ToolJet testDatasourceConnection failed (404): Not Found')
+      ),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed).toMatchObject({ status: 'unsupported', supported: false, datasource: { id: 'pg1' } });
+  });
+
+  it('keeps discovery failures as tool errors rather than blaming a datasource', async () => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockRejectedValue(new Error('connection refused by ToolJet API')),
+    });
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/connection refused by ToolJet API/);
+  });
+
   it('separates a permission denial from a connection fault', async () => {
     const client = clientWith({
       testDatasourceConnection: vi

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -338,6 +338,33 @@ describe('run_query tool', () => {
     expect(client.runQuery).toHaveBeenCalledOnce();
   });
 
+  it('recognizes a bounded Supabase get_rows query and requests remote-read approval', async () => {
+    const client = makeClient();
+    client.getQuery.mockResolvedValue({
+      id: 'failed-deploys', name: 'getFailedDeploys', kind: 'supabase', data_source_id: 'supa-main',
+      options: { operation: 'get_rows', get_table_name: 'deployments', get_limit: 100 },
+    });
+
+    const refused = await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'failed-deploys', version_id: 'v1',
+    });
+    expect(refused.isError).toBe(true);
+    expect(refused.content[0]!.text).toMatch(/remote supabase read.*user_confirmed_remote_read:true/i);
+    expect(refused.content[0]!.text).not.toMatch(/no proven read classifier/i);
+    expect(client.runQuery).not.toHaveBeenCalled();
+
+    client.runQuery.mockResolvedValue({ status: 'ok', data: [{ status: 'Failed' }] });
+    const approved = await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'failed-deploys', version_id: 'v1', user_confirmed_remote_read: true,
+    });
+    expect(textOf(approved)).toMatchObject({
+      status: 'ok',
+      data: [{ status: 'Failed' }],
+      warnings: [expect.stringMatching(/User-confirmed remote supabase read/i)],
+    });
+    expect(client.runQuery).toHaveBeenCalledOnce();
+  });
+
   it('truncates oversized REST data returned to MCP after the approved request completes', async () => {
     const client = makeClient();
     client.getQuery.mockResolvedValue({


### PR DESCRIPTION
Integration PR for joint Navaneeth and Abhinaba testing. Commits remain separate: (1) block unusable component geometry before apply, and (2) generalize datasource connectivity classification and bounded read verification across datasource kinds. Validation: 182 affected tests pass; the full suite retains its 3 pre-existing tool-annotation failures and matching 4 TypeScript annotation errors. The GitHub Gitleaks check is red because the ToolJet organization workflow has no GITLEAKS_LICENSE configured; the job reports no secret finding from this PR.