### PR TITLE
Integrate datasource and component-generation reliability fixes

### DIFF
--- a/scripts/generate-skill.mjs
+++ b/scripts/generate-skill.mjs
@@ -811,7 +811,7 @@ const events = makeReference(
 );
 const datasourceRepair = `## Missing or broken datasource recovery
 
-\`list_workspaces\` returns \`datasources_url\`; \`list_datasources\` returns a direct \`settings_url\` for each source; failed query runs may return \`recovery:{action:"open_datasource_settings",url,instruction}\`.
+\`list_workspaces\` returns \`datasources_url\`; \`list_datasources\` returns a direct \`settings_url\` for each source. Failed query runs carry a structured \`category\`: connection/authentication failures may return \`recovery:{action:"open_datasource_settings",url,instruction}\`; an \`unknown\` failure returns \`verification:{action:"test_datasource_connection",datasource_id,instruction}\`. Follow those fields instead of inferring from error text, and never substitute another datasource.
 
 When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh \`list_datasources\` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
 
@@ -820,7 +820,8 @@ When the expected datasource is absent or a connection-backed query fails, expla
 - \`ok\` — the connection works; a failing query is the query's fault.
 - \`failed\` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned \`recovery.url\`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - \`unsupported\` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: \`get_datasource_query_schema\` reports \`supports_test_connection\`, so you can skip the test rather than spend it.
-- \`not_permitted\` — this ToolJet user may not test connections. Also not a fault; say so and move on.`;
+- \`not_permitted\` — this ToolJet user may not test connections. Also not a fault; say so and move on.
+- \`inconclusive\` — ToolJet could not prove health or failure. Ask before running the returned bounded-read verification; do not substitute another datasource.`;
 const restApiGuidance = `## REST API queries
 
 For \`kind:"restapi"\`, fetch the contract for the intended HTTP method, but do not persist an \`operation\` option: REST queries are selected by \`method\`. \`headers\`, \`url_params\`, \`cookies\`, and structured \`body\` are arrays of two-item \`[key, value]\` tuples. For a raw body use \`body_toggle:true\` with \`raw_body\`; \`json_body\` is a legacy fallback for existing queries.

--- a/skill/references/datasources.md
+++ b/skill/references/datasources.md
@@ -14,6 +14,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 - `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: `get_datasource_query_schema` reports `supports_test_connection`, so you can skip the test rather than spend it.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
+- `inconclusive` — ToolJet could not prove health or failure. Ask before running the returned bounded-read verification; do not substitute another datasource.
 
 ### Large-data read safety
 

--- a/skill/references/datasources.md
+++ b/skill/references/datasources.md
@@ -4,7 +4,7 @@ Read this when selecting, connecting, introspecting, or authoring datasource que
 
 ## Missing or broken datasource recovery
 
-`list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source; failed query runs may return `recovery:{action:"open_datasource_settings",url,instruction}`.
+`list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source. Failed query runs carry a structured `category`: connection/authentication failures may return `recovery:{action:"open_datasource_settings",url,instruction}`; an `unknown` failure returns `verification:{action:"test_datasource_connection",datasource_id,instruction}`. Follow those fields instead of inferring from error text, and never substitute another datasource.
 
 When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
 

--- a/skills/tooljet-app-builder/references/datasources.md
+++ b/skills/tooljet-app-builder/references/datasources.md
@@ -14,6 +14,7 @@ When the expected datasource is absent or a connection-backed query fails, expla
 - `failed` — genuinely broken. Say WHY in your own words, quoting the datasource's own message (expired trial, suspended warehouse, refused connection, bad credentials), hand over the returned `recovery.url`, and stop building on it. Never restate an external outage as a limitation of yours — "I cannot run queries here" hides a problem the user can fix in two minutes. If you build anyway because they asked you to, repeat the cause and the link in your final handoff.
 - `unsupported` — this datasource kind publishes no connection test (REST API, GraphQL, and most OAuth/HTTP integrations). It says NOTHING about the connection: never report it as a fault. Verify with one bounded read instead. Which kinds these are is known ahead of the call: `get_datasource_query_schema` reports `supports_test_connection`, so you can skip the test rather than spend it.
 - `not_permitted` — this ToolJet user may not test connections. Also not a fault; say so and move on.
+- `inconclusive` — ToolJet could not prove health or failure. Ask before running the returned bounded-read verification; do not substitute another datasource.
 
 ### Large-data read safety
 

--- a/skills/tooljet-app-builder/references/datasources.md
+++ b/skills/tooljet-app-builder/references/datasources.md
@@ -4,7 +4,7 @@ Read this when selecting, connecting, introspecting, or authoring datasource que
 
 ## Missing or broken datasource recovery
 
-`list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source; failed query runs may return `recovery:{action:"open_datasource_settings",url,instruction}`.
+`list_workspaces` returns `datasources_url`; `list_datasources` returns a direct `settings_url` for each source. Failed query runs carry a structured `category`: connection/authentication failures may return `recovery:{action:"open_datasource_settings",url,instruction}`; an `unknown` failure returns `verification:{action:"test_datasource_connection",datasource_id,instruction}`. Follow those fields instead of inferring from error text, and never substitute another datasource.
 
 When the expected datasource is absent or a connection-backed query fails, explain the failure and ask the user to repair it. If the host has a built-in browser, open the most specific returned URL there; otherwise send the clickable link. Navigation is the only automated action: never enter credentials, authorize OAuth, or save settings for the user. Wait for the user to confirm the repair, then refresh `list_datasources` and retry at most one explicitly selected safe read. If it still fails, report the error instead of looping.
 

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -851,7 +851,7 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
   const rects = [spec.layout, spec.layouts?.desktop, spec.layouts?.mobile].filter(Boolean) as Rect[];
   for (const r of rects) {
     if ((r.width ?? 0) <= 0 || (r.height ?? 0) <= 0) {
-      warnings.push(`Component "${label}": layout has non-positive size (${r.width}×${r.height}) — it may be invisible.`);
+      errors.push(`Component "${label}": layout has non-positive size (${r.width}×${r.height}) — it may be invisible.`);
     }
   }
 
@@ -1240,7 +1240,9 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
         TABLE_FOOTER_HEIGHT_PX +
         TABLE_BORDER_PX;
       const minimumHeight = chromeHeight + rowsPerPage * rowHeight;
-      if (desktopHeight < minimumHeight) {
+      if (desktopHeight < chromeHeight + rowHeight) {
+        errors.push(`Table "${label}": desktop height ${desktopHeight}px cannot show even one data row.`);
+      } else if (desktopHeight < minimumHeight) {
         warnings.push(
           `Table "${label}": desktop height ${desktopHeight}px is too short to show ${rowsPerPage} ` +
             `${cellSize === 'condensed' ? 'condensed' : 'regular'} rows without an inner scrollbar; use about ` +
@@ -1648,7 +1650,6 @@ export function lintRenderedGeometry(components: LintComponent[]): string[] {
   return [
     ...detectOverlaps(components),
     ...lintModalChildren(components),
-    ...lintTextGeometry(components),
     ...lintListviewChildren(components),
     ...lintOperationalViewport(components),
     ...lintDesktopCanvasCoverage(components),
@@ -1667,6 +1668,7 @@ export function lintComponents(components: LintComponent[]): LintResult {
     warnings.push(...r.warnings);
   }
   errors.push(...lintComponentSlots(components));
+  errors.push(...lintTextGeometry(components));
   warnings.push(...lintRenderedGeometry(components));
   warnings.push(...lintKanbanInteractions(components));
   return { errors, warnings };
@@ -1938,6 +1940,7 @@ export function validateAppStructure(summary: AppSummary): LintResult {
   }
 
   for (const p of summary.pages) {
+    errors.push(...lintTextGeometry(p.components as LintComponent[]));
     warnings.push(...lintRenderedGeometry(p.components as LintComponent[]));
     warnings.push(...lintKanbanInteractions(p.components as LintComponent[]));
   }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -516,7 +516,7 @@ export function renderedHeight(component: LintComponent, rect?: Rect): number {
  *  component taller does not enlarge its value text; with a top-aligned label ToolJet adds a
  *  separate 20px rendered footprint outside that authored box. Treat the catalog's
  *  compactFormHeight hint as the source-of-truth marker instead of duplicating a component list. */
-function lintStandardSingleLineInputHeight(component: LintComponent): string[] {
+export function lintStandardSingleLineInputHeight(component: LintComponent): string[] {
   const schema = component.type ? getComponentSchema(component.type) : undefined;
   const defaultHeight = schema?.defaultSize?.height;
   if (!schema?.renderingHints?.compactFormHeight || defaultHeight === undefined) return [];
@@ -553,6 +553,41 @@ export function minimumTextHeight(component: LintComponent): number | undefined 
   const lineHeight = lineHeightValue === undefined ? 1.5 : optionalStaticNumber(lineHeightValue);
   if (textSize === undefined || lineHeight === undefined) return undefined;
   return Math.ceil(textSize * lineHeight + 6);
+}
+
+/** Height below the rendered line box itself is unusable; wrapper chrome is handled as a warning. */
+function minimumTextContentHeight(component: LintComponent): number | undefined {
+  const minimum = minimumTextHeight(component);
+  return minimum === undefined ? undefined : minimum - 6;
+}
+
+export function lintUnusableTextGeometry(components: LintComponent[]): string[] {
+  const errors: string[] = [];
+  for (const component of components) {
+    const minimum = minimumTextContentHeight(component);
+    if (minimum === undefined) continue;
+    const layouts: Array<[string, Rect | undefined]> = [
+      [component.layouts?.desktop ? 'desktop' : 'layout', component.layouts?.desktop ?? component.layout],
+      ['mobile', component.layouts?.mobile],
+    ];
+    const undersized = layouts.filter((entry): entry is [string, Rect] =>
+      !!entry[1] && typeof entry[1].height === 'number' && entry[1].height < minimum
+    );
+    if (undersized.length) {
+      const recommended = minimumTextHeight(component)!;
+      errors.push(
+        `Text "${component.name ?? component.id ?? 'Text'}" is too short to render one line: ` +
+          `${undersized.map(([resolution, layout]) => `${resolution} height ${layout.height}px`).join(', ')}; ` +
+          `use at least ${recommended}px or enable dynamicHeight.`
+      );
+    }
+  }
+  return errors;
+}
+
+export function introducedLintFindings(before: string[], after: string[]): string[] {
+  const existing = new Set(before);
+  return after.filter((finding) => !existing.has(finding));
 }
 
 export function lintTextGeometry(components: LintComponent[]): string[] {
@@ -1241,7 +1276,10 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
         TABLE_BORDER_PX;
       const minimumHeight = chromeHeight + rowsPerPage * rowHeight;
       if (desktopHeight < chromeHeight + rowHeight) {
-        errors.push(`Table "${label}": desktop height ${desktopHeight}px cannot show even one data row.`);
+        errors.push(
+          `Table "${label}": desktop height ${desktopHeight}px cannot show even one data row; ` +
+            `use at least ${chromeHeight + rowHeight}px.`
+        );
       } else if (desktopHeight < minimumHeight) {
         warnings.push(
           `Table "${label}": desktop height ${desktopHeight}px is too short to show ${rowsPerPage} ` +
@@ -1668,7 +1706,8 @@ export function lintComponents(components: LintComponent[]): LintResult {
     warnings.push(...r.warnings);
   }
   errors.push(...lintComponentSlots(components));
-  errors.push(...lintTextGeometry(components));
+  errors.push(...lintUnusableTextGeometry(components));
+  warnings.push(...lintTextGeometry(components));
   warnings.push(...lintRenderedGeometry(components));
   warnings.push(...lintKanbanInteractions(components));
   return { errors, warnings };
@@ -1940,7 +1979,8 @@ export function validateAppStructure(summary: AppSummary): LintResult {
   }
 
   for (const p of summary.pages) {
-    errors.push(...lintTextGeometry(p.components as LintComponent[]));
+    errors.push(...lintUnusableTextGeometry(p.components as LintComponent[]));
+    warnings.push(...lintTextGeometry(p.components as LintComponent[]));
     warnings.push(...lintRenderedGeometry(p.components as LintComponent[]));
     warnings.push(...lintKanbanInteractions(p.components as LintComponent[]));
   }

--- a/src/queryExecutionSafety.ts
+++ b/src/queryExecutionSafety.ts
@@ -170,14 +170,18 @@ function assessSupabase(options: Record<string, unknown>, datasourceId?: string)
   const operation = typeof options.operation === 'string' ? options.operation.toLowerCase() : '';
   const table = operation === 'count_rows' ? options.count_table_name : options.get_table_name;
   const identity = { datasourceKind: 'supabase', ...(datasourceId ? { datasourceId } : {}) };
-  if (!['get_rows', 'count_rows'].includes(operation) || typeof table !== 'string' || !table.trim()) {
+  if (!['get_rows', 'count_rows'].includes(operation) || typeof table !== 'string' || !table.trim() || containsBinding(table)) {
     return { provenRead: false, directSafe: false, countOnly: false, selectStar: false,
       requiresCountPreflight: false, reason: 'Supabase operation is not a static row read.', ...identity };
   }
   const source = { kind: 'remote_endpoint' as const, value: `supabase:${table.trim().toLowerCase()}` };
   if (operation === 'count_rows') {
+    const countFilters = options.count_filters;
+    const fullSourceCount = countFilters == null ||
+      (Array.isArray(countFilters) && countFilters.length === 0) ||
+      (!!record(countFilters) && Object.keys(record(countFilters)!).length === 0);
     return { provenRead: true, directSafe: false, countOnly: true, selectStar: false,
-      requiresCountPreflight: false, requiresRemoteReadConfirmation: true, fullSourceCount: true,
+      requiresCountPreflight: false, requiresRemoteReadConfirmation: true, fullSourceCount,
       simpleSourceRead: true, maxRows: 1, source, ...identity };
   }
   const maxRows = staticPositiveInteger(options.get_limit);

--- a/src/queryExecutionSafety.ts
+++ b/src/queryExecutionSafety.ts
@@ -166,6 +166,26 @@ function assessRestGet(options: Record<string, unknown>, datasourceId?: string):
   };
 }
 
+function assessSupabase(options: Record<string, unknown>, datasourceId?: string): QueryReadAssessment {
+  const operation = typeof options.operation === 'string' ? options.operation.toLowerCase() : '';
+  const table = operation === 'count_rows' ? options.count_table_name : options.get_table_name;
+  const identity = { datasourceKind: 'supabase', ...(datasourceId ? { datasourceId } : {}) };
+  if (!['get_rows', 'count_rows'].includes(operation) || typeof table !== 'string' || !table.trim()) {
+    return { provenRead: false, directSafe: false, countOnly: false, selectStar: false,
+      requiresCountPreflight: false, reason: 'Supabase operation is not a static row read.', ...identity };
+  }
+  const source = { kind: 'remote_endpoint' as const, value: `supabase:${table.trim().toLowerCase()}` };
+  if (operation === 'count_rows') {
+    return { provenRead: true, directSafe: false, countOnly: true, selectStar: false,
+      requiresCountPreflight: false, requiresRemoteReadConfirmation: true, fullSourceCount: true,
+      simpleSourceRead: true, maxRows: 1, source, ...identity };
+  }
+  const maxRows = staticPositiveInteger(options.get_limit);
+  return { provenRead: true, directSafe: false, countOnly: false, selectStar: false,
+    requiresCountPreflight: maxRows === undefined || maxRows > LARGE_READ_ROW_THRESHOLD,
+    requiresRemoteReadConfirmation: true, simpleSourceRead: true, source, maxRows, ...identity };
+}
+
 function stripSql(sql: string): string {
   return sql.replace(/--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '').trim().replace(/;\s*$/, '').trim();
 }
@@ -363,6 +383,8 @@ export function assessQueryRead(query: QuerySummary): QueryReadAssessment {
   if (kind === 'restapi') return assessRestGet(options, datasourceId);
 
   if (kind === 'servicenow') return assessServiceNow(options, datasourceId);
+
+  if (kind === 'supabase') return assessSupabase(options, datasourceId);
 
   if (kind === 'tooljetdb') {
     if (operation === 'list_rows') return assessListRows(kind, options, datasourceId);

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -607,8 +607,13 @@ export interface UpdateEventsParams {
 }
 
 export class ToolJetHttpError extends Error {
-  constructor(public readonly status: number, method: string, detail: string) {
+  constructor(
+    public readonly status: number,
+    public readonly method: string,
+    public readonly detail: string
+  ) {
     super(`ToolJet ${method} failed (${status}): ${detail}`);
+    this.name = 'ToolJetHttpError';
   }
 }
 

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -588,6 +588,16 @@ export interface UpdateQueryParams {
 /** Run/preview result — `status` is 'ok' or 'failed' (HTTP is 200 either way); rows under `data`. */
 export interface RunQueryResult {
   status: string;
+  /** Structured by ToolJet's plugin boundary; never inferred from human-readable error text. */
+  category?:
+    | 'authentication'
+    | 'connection'
+    | 'schema_name'
+    | 'timeout'
+    | 'rate_limit'
+    | 'transient'
+    | 'query'
+    | 'unknown';
   data?: unknown;
   message?: string;
   [k: string]: unknown;

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -606,9 +606,15 @@ export interface UpdateEventsParams {
   updateType?: 'update' | 'reorder';
 }
 
+export class ToolJetHttpError extends Error {
+  constructor(public readonly status: number, method: string, detail: string) {
+    super(`ToolJet ${method} failed (${status}): ${detail}`);
+  }
+}
+
 async function assertOk(res: Response, method: string): Promise<void> {
   if (!res.ok) {
-    throw new Error(`ToolJet ${method} failed (${res.status}): ${await res.text()}`);
+    throw new ToolJetHttpError(res.status, method, await res.text());
   }
 }
 

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -382,10 +382,12 @@ export interface TestDatasourceConnectionParams {
   environmentId?: string;
 }
 
-/** ToolJet's own test-connection verdict. `status` is 'ok' or 'failed'; a plugin that does not
- *  implement testConnection also arrives here as 'failed', which the tool separates out. */
+/** ToolJet's own test-connection verdict. Unsupported plugins preserve the existing `failed`
+ *  status for compatibility and add a structured `category`. */
 export interface ConnectionTestResult {
   status: string;
+  category?: string;
+  supported?: boolean;
   message?: string;
   [key: string]: unknown;
 }

--- a/src/tools/runQueries.ts
+++ b/src/tools/runQueries.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { QuerySummary, ToolJetClient } from '../tooljetClient.js';
 import { assessQueryRead } from '../queryExecutionSafety.js';
-import { containsComponentBinding, failureRecovery, schemaNameHint } from './runQuery.js';
+import { containsComponentBinding, failureRecovery, failureVerification, schemaNameHint } from './runQuery.js';
 import { ok, fail, type ToolDef } from './types.js';
 import { resolveRef } from '../refResolution.js';
 
@@ -95,6 +95,7 @@ export function runQueriesTool(client: ToolJetClient): ToolDef {
             const result = await client.runQuery({ queryId, versionId: args.version_id, environmentId });
             const failed = result.status === 'failed';
             const recovery = failed ? failureRecovery(query, result as Record<string, unknown>) : undefined;
+            const verification = failed ? failureVerification(query, result as Record<string, unknown>) : undefined;
             const schemaHint = failed ? await schemaNameHint(client, query, result as Record<string, unknown>) : undefined;
             // include_data:false keeps only the run status (+ row_count), dropping the row payload — the
             // caller just needs to confirm the query executed, and a large data array would bloat/risk the
@@ -112,6 +113,7 @@ export function runQueriesTool(client: ToolJetClient): ToolDef {
               ...shaped,
               ...(warnings.length ? { warnings } : {}),
               ...(recovery ? { recovery } : {}),
+              ...(verification ? { verification } : {}),
               ...(schemaHint ? { schema_hint: schemaHint } : {}),
             };
           } catch (error) {

--- a/src/tools/runQueries.ts
+++ b/src/tools/runQueries.ts
@@ -116,15 +116,11 @@ export function runQueriesTool(client: ToolJetClient): ToolDef {
             };
           } catch (error) {
             const failure = { status: 'failed', message: error instanceof Error ? error.message : String(error) };
-            const recovery = failureRecovery(query, failure);
-            const schemaHint = await schemaNameHint(client, query, failure);
             return {
               query_id: queryId,
               ...(query.name ? { name: query.name } : {}),
               ...failure,
               ...(warnings.length ? { warnings } : {}),
-              ...(recovery ? { recovery } : {}),
-              ...(schemaHint ? { schema_hint: schemaHint } : {}),
             };
           }
         }));

--- a/src/tools/runQuery.ts
+++ b/src/tools/runQuery.ts
@@ -62,21 +62,37 @@ export function datasourceRecovery(query: {
   };
 }
 
-export type QueryFailureClass = 'connection' | 'schema_name' | 'query';
+export type QueryFailureClass = 'connection' | 'schema_name' | 'query' | 'unknown';
 
 const CONNECTION_SQLSTATE_PREFIXES = ['08', '28', '53', '57P0', '3D000'];
 const SCHEMA_NAME_SQLSTATES = new Set(['42P01', '42703', '3F000', '42P02', '42704']);
+const LEGACY_CONNECTION_CODES = new Set([
+  'ELOGIN', 'ESOCKET', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND',
+  'ER_ACCESS_DENIED_ERROR', 'ER_DBACCESS_DENIED_ERROR', 'ER_BAD_DB_ERROR', 'PROTOCOL_CONNECTION_LOST',
+]);
+const LEGACY_SCHEMA_CODES = new Set(['ER_BAD_FIELD_ERROR', 'ER_BAD_TABLE_ERROR', 'ER_NO_SUCH_TABLE']);
 
 /** Classify a failed query result so the caller offers the RIGHT recovery: a connection-repair
  *  handoff only for genuine connection failures, and a re-introspect hint for wrong table/column
  *  names — never the misleading "go fix your datasource" prompt for a plain SQL name error. */
 export function classifyQueryFailure(result: Record<string, unknown> | undefined): QueryFailureClass {
-  if (!result) return 'query';
-  const data = result.data as { code?: unknown } | undefined;
-  const code = data && typeof data === 'object' ? String(data.code ?? '') : '';
-  if (CONNECTION_SQLSTATE_PREFIXES.some((prefix) => code.startsWith(prefix))) return 'connection';
-  if (SCHEMA_NAME_SQLSTATES.has(code)) return 'schema_name';
-  return 'query';
+  if (!result) return 'unknown';
+  const category = result.category;
+  if (category === 'authentication' || category === 'connection') return 'connection';
+  if (category === 'schema_name') return 'schema_name';
+  if (category === 'unknown') return 'unknown';
+  if (['timeout', 'rate_limit', 'transient', 'query'].includes(String(category))) return 'query';
+  if (typeof category === 'string') return 'unknown';
+
+  // Compatibility with older ToolJet servers: inspect structured driver fields only.
+  const data = result.data as { code?: unknown; sqlState?: unknown; sqlstate?: unknown } | undefined;
+  const codes = data && typeof data === 'object'
+    ? [data.code, data.sqlState, data.sqlstate].map((value) => String(value ?? '').toUpperCase()).filter(Boolean)
+    : [];
+  if (codes.some((code) => CONNECTION_SQLSTATE_PREFIXES.some((prefix) => code.startsWith(prefix))) ||
+      codes.some((code) => LEGACY_CONNECTION_CODES.has(code))) return 'connection';
+  if (codes.some((code) => SCHEMA_NAME_SQLSTATES.has(code) || LEGACY_SCHEMA_CODES.has(code))) return 'schema_name';
+  return codes.length ? 'query' : 'unknown';
 }
 
 /** Connection-repair handoff ONLY when the failure is actually a connection problem. */
@@ -85,6 +101,21 @@ export function failureRecovery(
   result: Record<string, unknown>
 ): Record<string, unknown> | undefined {
   return classifyQueryFailure(result) === 'connection' ? datasourceRecovery(query) : undefined;
+}
+
+/** Unknown means exactly that: verify the saved datasource instead of guessing or switching it. */
+export function failureVerification(
+  query: { data_source_id?: string },
+  result: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!query.data_source_id || classifyQueryFailure(result) !== 'unknown') return undefined;
+  return {
+    action: 'test_datasource_connection',
+    datasource_id: query.data_source_id,
+    instruction:
+      'Test this same saved datasource before diagnosing the failure. If testing is unsupported or inconclusive, ' +
+      'ask the user before one bounded read. Never substitute another datasource from an unknown failure.',
+  };
 }
 
 function introspectedNames(result: unknown): string[] {
@@ -304,6 +335,7 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
         }
         const failed = result.status === 'failed';
         const recovery = failed ? failureRecovery(query, result as Record<string, unknown>) : undefined;
+        const verification = failed ? failureVerification(query, result as Record<string, unknown>) : undefined;
         const schemaHint = failed ? await schemaNameHint(client, query, result as Record<string, unknown>) : undefined;
         const output = assessment.requiresRemoteReadConfirmation
           ? truncateRemoteResult(result as Record<string, unknown>)
@@ -314,6 +346,7 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
           ...(preflight ? { preflight } : {}),
           ...(warnings.length ? { warnings } : {}),
           ...(recovery ? { recovery } : {}),
+          ...(verification ? { verification } : {}),
           ...(schemaHint ? { schema_hint: schemaHint } : {}),
         });
       } catch (err) {

--- a/src/tools/runQuery.ts
+++ b/src/tools/runQuery.ts
@@ -64,18 +64,8 @@ export function datasourceRecovery(query: {
 
 export type QueryFailureClass = 'connection' | 'schema_name' | 'query';
 
-// SQLSTATE prefixes / message markers that mean the *connection* is broken (agent cannot fix by
-// editing SQL — the user must repair the datasource). Postgres classes: 08 connection_exception,
-// 28 invalid_authorization, 53 insufficient_resources, 57P0x admin/cannot-connect, 3D000 invalid_catalog.
-const CONNECTION_SQLSTATE = /^(08|28|53|57P0|3D000)/;
-const CONNECTION_MESSAGE =
-  /econnrefused|etimedout|enotfound|ehostunreach|econnreset|getaddrinfo|connection (refused|reset|closed|terminated|timed out)|could not connect|couldn'?t connect|authentication failed|password authentication|no pg_hba|timeout expired|server closed the connection|too many connections|access denied for user|login failed for user/i;
-// SQLSTATE / markers that mean a NAME in the query does not exist — recoverable by re-introspecting.
-// 42P01 undefined_table, 42703 undefined_column, 3F000 invalid_schema, 42P02 undefined_parameter, 42704
-// undefined_object.
-const SCHEMA_NAME_SQLSTATE = /^(42P01|42703|3F000|42P02|42704)/;
-const SCHEMA_NAME_MESSAGE =
-  /(relation|column|table|schema|function|type)\b.{0,40}\bdoes(n'?t| not) exist|unknown column|no such (table|column)|invalid object name/i;
+const CONNECTION_SQLSTATE_PREFIXES = ['08', '28', '53', '57P0', '3D000'];
+const SCHEMA_NAME_SQLSTATES = new Set(['42P01', '42703', '3F000', '42P02', '42704']);
 
 /** Classify a failed query result so the caller offers the RIGHT recovery: a connection-repair
  *  handoff only for genuine connection failures, and a re-introspect hint for wrong table/column
@@ -84,9 +74,8 @@ export function classifyQueryFailure(result: Record<string, unknown> | undefined
   if (!result) return 'query';
   const data = result.data as { code?: unknown } | undefined;
   const code = data && typeof data === 'object' ? String(data.code ?? '') : '';
-  const text = `${result.description ?? ''} ${result.message ?? ''}`;
-  if ((code && CONNECTION_SQLSTATE.test(code)) || CONNECTION_MESSAGE.test(text)) return 'connection';
-  if ((code && SCHEMA_NAME_SQLSTATE.test(code)) || SCHEMA_NAME_MESSAGE.test(text)) return 'schema_name';
+  if (CONNECTION_SQLSTATE_PREFIXES.some((prefix) => code.startsWith(prefix))) return 'connection';
+  if (SCHEMA_NAME_SQLSTATES.has(code)) return 'schema_name';
   return 'query';
 }
 
@@ -190,8 +179,8 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
       `observed count is larger, retry only after explicit user approval with user_confirmed_large_read:true. ` +
       'BigQuery, Snowflake, and Redshift reads also require explicit cost approval with ' +
       'user_confirmed_billable_read:true, even when row-limited. Never set confirmation flags from inferred consent. ' +
-      'A static REST GET requires separate approval with user_confirmed_remote_read:true because it may expose sensitive ' +
-      'data, consume quota, or return an unbounded payload; REST writes and binding-dependent requests are always refused. ' +
+      'A static remote read (including REST GET and Supabase rows) requires separate approval with ' +
+      'user_confirmed_remote_read:true because it may expose sensitive data or consume quota; remote writes are refused. ' +
       'If saved options reference `components.*`, the result ' +
       'includes a warning because browser-free execution cannot prove the component-resolved pagination/filter behavior.',
     inputSchema: {
@@ -229,15 +218,15 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
 
         if (assessment.requiresRemoteReadConfirmation && !args.user_confirmed_remote_read) {
           return fail(new Error(
-            `run_query refused REST GET "${query.name ?? query.id}" before execution: remote reads can expose sensitive ` +
+            `run_query refused remote read "${query.name ?? query.id}" before execution: remote reads can expose sensitive ` +
               'data, consume API quota, and return an unbounded payload. Tell the user which saved query will run and ask ' +
               'explicitly; retry with user_confirmed_remote_read:true only after they approve that request.'
           ));
         }
         if (assessment.requiresRemoteReadConfirmation) {
-          warnings.push(
-            'User-confirmed REST GET: the remote API controls response size and quota. Inspect metadata.request and metadata.response, and add API-specific pagination before another run when needed.'
-          );
+          warnings.push(assessment.datasourceKind === 'restapi'
+            ? 'User-confirmed REST GET: the remote API controls response size and quota. Inspect metadata.request and metadata.response, and add API-specific pagination before another run when needed.'
+            : 'User-confirmed remote read: the datasource controls response size and quota.');
         }
 
         if (assessment.requiresBillableReadConfirmation && !args.user_confirmed_billable_read) {

--- a/src/tools/runQuery.ts
+++ b/src/tools/runQuery.ts
@@ -252,7 +252,8 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
           const countQuery = await client.getQuery(args.count_query_id, args.version_id);
           const countAssessment = assessQueryRead(countQuery);
           const countCanRun = countAssessment.directSafe ||
-            (countAssessment.requiresBillableReadConfirmation === true && args.user_confirmed_billable_read === true);
+            (countAssessment.requiresBillableReadConfirmation === true && args.user_confirmed_billable_read === true) ||
+            (countAssessment.requiresRemoteReadConfirmation === true && args.user_confirmed_remote_read === true);
           if (!countAssessment.countOnly || !countCanRun || countAssessment.requiresCountPreflight ||
               !sameReadSource(assessment, countAssessment)) {
             return fail(new Error(
@@ -294,15 +295,11 @@ export function runQueryTool(client: ToolJetClient): ToolDef {
             environmentId: args.environment_id,
           });
         } catch (error) {
-          const failure = { status: 'failed', message: error instanceof Error ? error.message : String(error) };
-          const recovery = failureRecovery(query, failure);
-          const schemaHint = await schemaNameHint(client, query, failure);
           return ok({
-            ...failure,
+            status: 'failed',
+            message: error instanceof Error ? error.message : String(error),
             ...(preflight ? { preflight } : {}),
             ...(warnings.length ? { warnings } : {}),
-            ...(recovery ? { recovery } : {}),
-            ...(schemaHint ? { schema_hint: schemaHint } : {}),
           });
         }
         const failed = result.status === 'failed';

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -132,7 +132,15 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
             message: 'ToolJet has no datasource-level test endpoint. This says nothing about connection health.',
           });
         }
-        return inconclusive(header, err instanceof Error ? err.message : String(err));
+        if (err instanceof ToolJetHttpError && err.method === 'testDatasourceConnection' && err.status === 501) {
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message: 'This ToolJet datasource plugin does not implement a connection test.',
+          });
+        }
+        return fail(err);
       }
     },
   };

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ToolJetClient } from '../tooljetClient.js';
+import { ToolJetHttpError, type ToolJetClient } from '../tooljetClient.js';
 import { ok, fail, type ToolDef } from './types.js';
 import { getDatasourceQuerySchema } from '../datasourceCatalog.js';
 
@@ -10,7 +10,7 @@ import { getDatasourceQuerySchema } from '../datasourceCatalog.js';
  * and ToolJet's util.service catches the resulting NotImplementedException and flattens it into a
  * normal `{status:'failed'}`. Reported as-is, that reads as "your working Stripe source is down".
  */
-const NOT_IMPLEMENTED = /testconnection method not implemented/i;
+const CONNECTION_FAILURE_CATEGORIES = new Set(['connection', 'authentication', 'network', 'tls', 'credentials']);
 
 /** Identical whether the catalog pre-empted the call or ToolJet answered it, so the model cannot
  *  tell the two paths apart and cannot come to depend on the difference. */
@@ -23,12 +23,14 @@ function unsupportedMessage(kind: string): string {
 
 /** Permission, not health: TEST_CONNECTION is granted to admins, datasource create/delete holders,
  *  all-editable/all-viewable, and per-datasource configurable grants — but NOT to a bare builder. */
-function isForbidden(message: string): boolean {
-  return /\(403\)/.test(message) || /forbidden/i.test(message);
-}
-
-function isNotFound(message: string): boolean {
-  return /\(404\)/.test(message);
+function inconclusive(header: Record<string, unknown>, detail?: string) {
+  return ok({
+    ...header,
+    supported: true,
+    status: 'inconclusive',
+    message: `The connection test did not prove this datasource is broken${detail ? ` (${detail.trim()})` : ''}.`,
+    verification: { action: 'ask_then_run_bounded_read', requires_user_approval: true },
+  });
 }
 
 export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
@@ -53,6 +55,7 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
       datasource_id: z.string().min(1),
     },
     async handler(args: { version_id: string; datasource_id: string }) {
+      let header: Record<string, unknown> | undefined;
       try {
         const datasource = (await client.listDatasources(args.version_id)).find(
           (candidate) => candidate.id === args.datasource_id
@@ -62,7 +65,7 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
             new Error(`Datasource "${args.datasource_id}" is not available on version "${args.version_id}".`)
           );
         }
-        const header = {
+        header = {
           datasource: { id: datasource.id, name: datasource.name, kind: datasource.kind },
           settings_url: datasource.settings_url,
         };
@@ -88,18 +91,11 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         });
 
         const message = typeof result.message === 'string' ? result.message : undefined;
-        if (message && NOT_IMPLEMENTED.test(message)) {
-          return ok({
-            ...header,
-            supported: false,
-            status: 'unsupported',
-            message: unsupportedMessage(datasource.kind),
-          });
-        }
-
         if (result.status === 'ok') {
           return ok({ ...header, supported: true, status: 'ok' });
         }
+        const category = typeof result.category === 'string' ? result.category.toLowerCase() : '';
+        if (!CONNECTION_FAILURE_CATEGORIES.has(category)) return inconclusive(header, message);
         return ok({
           ...header,
           supported: true,
@@ -114,12 +110,12 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
           },
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        if (!header) return fail(err);
         // A permission denial is about the caller, not the datasource. Returned as a normal result
         // so the model reports it accurately instead of announcing a broken source.
-        if (isForbidden(message)) {
+        if (err instanceof ToolJetHttpError && err.status === 403) {
           return ok({
-            datasource: { id: args.datasource_id },
+            ...header,
             supported: true,
             status: 'not_permitted',
             message:
@@ -128,15 +124,15 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
               'The connection itself was not tested.',
           });
         }
-        if (isNotFound(message)) {
-          return fail(
-            new Error(
-              `ToolJet has no test-connection endpoint or no datasource "${args.datasource_id}" for this ` +
-                `environment (${message}).`
-            )
-          );
+        if (err instanceof ToolJetHttpError && err.status === 404) {
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message: 'ToolJet has no datasource-level test endpoint. This says nothing about connection health.',
+          });
         }
-        return fail(err);
+        return inconclusive(header, err instanceof Error ? err.message : String(err));
       }
     },
   };

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -10,8 +10,6 @@ import { getDatasourceQuerySchema } from '../datasourceCatalog.js';
  * and ToolJet's util.service catches the resulting NotImplementedException and flattens it into a
  * normal `{status:'failed'}`. Reported as-is, that reads as "your working Stripe source is down".
  */
-const CONNECTION_FAILURE_CATEGORIES = new Set(['connection', 'authentication', 'network', 'tls', 'credentials']);
-
 /** Identical whether the catalog pre-empted the call or ToolJet answered it, so the model cannot
  *  tell the two paths apart and cannot come to depend on the difference. */
 function unsupportedMessage(kind: string): string {
@@ -73,7 +71,8 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         // The catalog knows which plugins implement testConnection, so an unsupported kind costs no
         // HTTP calls. Only an explicit false short-circuits: an undefined flag means a stale or
         // partial catalog, which must degrade to asking ToolJet rather than to a wrong answer.
-        if (getDatasourceQuerySchema(datasource.kind)?.supportsTestConnection === false) {
+        const supportsTestConnection = getDatasourceQuerySchema(datasource.kind)?.supportsTestConnection;
+        if (supportsTestConnection === false) {
           return ok({
             ...header,
             supported: false,
@@ -94,8 +93,9 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         if (result.status === 'ok') {
           return ok({ ...header, supported: true, status: 'ok' });
         }
-        const category = typeof result.category === 'string' ? result.category.toLowerCase() : '';
-        if (!CONNECTION_FAILURE_CATEGORIES.has(category)) return inconclusive(header, message);
+        // ToolJet's endpoint contract is {status,message}; it does not return an error category.
+        // A failed verdict is authoritative only when the catalog says this plugin implements the test.
+        if (supportsTestConnection !== true) return inconclusive(header, message);
         return ok({
           ...header,
           supported: true,
@@ -113,7 +113,7 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         if (!header) return fail(err);
         // A permission denial is about the caller, not the datasource. Returned as a normal result
         // so the model reports it accurately instead of announcing a broken source.
-        if (err instanceof ToolJetHttpError && err.status === 403) {
+        if (err instanceof ToolJetHttpError && err.method === 'testDatasourceConnection' && err.status === 403) {
           return ok({
             ...header,
             supported: true,
@@ -124,7 +124,7 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
               'The connection itself was not tested.',
           });
         }
-        if (err instanceof ToolJetHttpError && err.status === 404) {
+        if (err instanceof ToolJetHttpError && err.method === 'testDatasourceConnection' && err.status === 404) {
           return ok({
             ...header,
             supported: false,

--- a/src/tools/testDatasourceConnection.ts
+++ b/src/tools/testDatasourceConnection.ts
@@ -90,6 +90,14 @@ export function testDatasourceConnectionTool(client: ToolJetClient): ToolDef {
         });
 
         const message = typeof result.message === 'string' ? result.message : undefined;
+        if (result.category === 'unsupported') {
+          return ok({
+            ...header,
+            supported: false,
+            status: 'unsupported',
+            message: unsupportedMessage(datasource.kind),
+          });
+        }
         if (result.status === 'ok') {
           return ok({ ...header, supported: true, status: 'ok' });
         }

--- a/src/tools/updateComponents.ts
+++ b/src/tools/updateComponents.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
 import type { ToolJetClient } from '../tooljetClient.js';
 import {
+  introducedLintFindings,
   lintComponentSlots,
   lintComponentSpec,
   lintKanbanInteractions,
   lintRenderedGeometry,
+  lintStandardSingleLineInputHeight,
+  lintTextGeometry,
+  lintUnusableTextGeometry,
   type LintComponent,
 } from '../lint.js';
 import { COMPONENT_SLOT_NAMES, decodeComponentParent, encodeComponentParent } from '../componentParent.js';
@@ -68,10 +72,11 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
         const summary = await client.getAppSummary(args.app_id);
         const page = summary.pages.find((candidate) => candidate.id === args.page_id);
         if (!page) return fail(new Error(`Page "${args.page_id}" does not exist in app "${args.app_id}".`));
-        const components = new Map(page.components.map((component) => [component.id, component]));
         const projected = new Map(page.components.map((component) => [component.id, component as LintComponent]));
         const warnings: string[] = [];
         const errors: string[] = [];
+        const changedComponents: Array<{ before: LintComponent; after: LintComponent }> = [];
+        let placementChanged = false;
         const resolvedUpdates: Array<{
           componentId: string;
           definition?: Record<string, unknown>;
@@ -147,8 +152,10 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
             layouts: next.layouts,
             parent: next.parent,
           });
-          const normalizedNext = normalized.component as LintComponent;
+          const normalizedNext = { ...normalized.component, id: current.id } as LintComponent;
           projected.set(current.id, normalizedNext);
+          if (update.definition) changedComponents.push({ before: current as LintComponent, after: normalizedNext });
+          placementChanged ||= update.parent !== undefined || update.slot_name !== undefined;
           warnings.push(...normalized.warnings);
           let normalizedDefinition = update.definition;
           if (update.definition && Object.keys(normalized.patch).length) {
@@ -170,14 +177,32 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
             slotName: update.slot_name,
           });
           if (!update.definition) continue;
-          const lint = lintComponentSpec(normalizedNext);
-          errors.push(...lint.errors);
-          warnings.push(...lint.warnings);
+          errors.push(...introducedLintFindings(
+            lintComponentSpec(current as LintComponent).errors,
+            lintComponentSpec(normalizedNext).errors
+          ));
+          warnings.push(...introducedLintFindings(
+            lintComponentSpec(current as LintComponent).warnings,
+            lintComponentSpec(normalizedNext).warnings
+          ));
         }
-        errors.push(...lintComponentSlots([...projected.values()]));
+        const allComponents = [...projected.values()];
+        const introducedForChanged = (lint: (components: LintComponent[]) => string[]) =>
+          changedComponents.flatMap(({ before, after }) =>
+            introducedLintFindings(lint([before]), lint([after]))
+          );
+        if (placementChanged) {
+          errors.push(...introducedLintFindings(
+            lintComponentSlots(page.components as LintComponent[]),
+            lintComponentSlots(allComponents)
+          ));
+        }
+        errors.push(...introducedForChanged(lintUnusableTextGeometry));
         if (errors.length) return fail(new Error(errors.join(' ')));
-        warnings.push(...lintRenderedGeometry([...projected.values()]));
-        warnings.push(...lintKanbanInteractions([...projected.values()]));
+        warnings.push(...introducedForChanged((items) => items.flatMap(lintStandardSingleLineInputHeight)));
+        warnings.push(...introducedForChanged(lintTextGeometry));
+        warnings.push(...lintRenderedGeometry(allComponents));
+        warnings.push(...lintKanbanInteractions(allComponents));
         const result = await client.updateComponents({
           appId: args.app_id,
           versionId: args.version_id,

--- a/src/tools/updateLayout.ts
+++ b/src/tools/updateLayout.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod';
 import type { ToolJetClient } from '../tooljetClient.js';
-import { lintComponentSlots, lintComponentSpec, lintRenderedGeometry, type LintComponent } from '../lint.js';
+import {
+  introducedLintFindings,
+  lintComponentSlots,
+  lintComponentSpec,
+  lintRenderedGeometry,
+  lintStandardSingleLineInputHeight,
+  lintTextGeometry,
+  lintUnusableTextGeometry,
+  type LintComponent,
+} from '../lint.js';
 import { COMPONENT_SLOT_NAMES, decodeComponentParent, encodeComponentParent } from '../componentParent.js';
 import { ok, fail, type ToolDef } from './types.js';
 import { resolveRef } from '../refResolution.js';
@@ -119,15 +128,28 @@ export function updateLayoutTool(client: ToolJetClient): ToolDef {
             slotName: change.slot_name,
           } as LintComponent;
         });
-        const slotErrors = lintComponentSlots(projected);
-        if (slotErrors.length) return fail(new Error(slotErrors.join(' ')));
         const changedIds = new Set(resolvedLayouts.map((layout) => layout.component_id));
+        const changed = projected.filter((component) => component.id && changedIds.has(component.id));
+        const introducedForChanged = (
+          lint: (components: LintComponent[]) => string[]
+        ) => changed.flatMap((component) =>
+          introducedLintFindings(lint([components.get(component.id!) as LintComponent]), lint([component]))
+        );
+        const errors = [
+          ...introducedLintFindings(
+            lintComponentSlots(page.components as LintComponent[]),
+            lintComponentSlots(projected)
+          ),
+          ...introducedForChanged((items) => items.flatMap((component) => lintComponentSpec(component).errors)),
+          ...introducedForChanged(lintUnusableTextGeometry),
+        ];
+        if (errors.length) return fail(new Error(errors.join(' ')));
         const warnings = [...new Set([
           ...layoutWarnings,
           ...rootSlotWarnings,
-          ...projected
-            .filter((component) => component.id && changedIds.has(component.id))
-            .flatMap((component) => lintComponentSpec(component).warnings),
+          ...introducedForChanged((items) => items.flatMap((component) => lintComponentSpec(component).warnings)),
+          ...introducedForChanged((items) => items.flatMap(lintStandardSingleLineInputHeight)),
+          ...introducedForChanged(lintTextGeometry),
           ...lintRenderedGeometry(projected),
         ])];
         const result = await client.updateLayouts({

--- a/tests/appSpecLint.test.ts
+++ b/tests/appSpecLint.test.ts
@@ -208,7 +208,7 @@ describe('lint_app_spec', () => {
     expect(body.errors.join(' ')).toMatch(/unknown.*target_ref/i);
     expect(body.errors.join(' ')).toMatch(/trigger "onChange" is not valid for Button/i);
     expect(body.warnings.join(' ')).toMatch(/order_filters|Unknown option key/i);
-    expect(body.warnings.join(' ')).toMatch(/too short.*single line needs/i);
+    expect(body.errors.join(' ')).toMatch(/too short.*single line needs/i);
   });
 
   it('requires at least one spec section', async () => {

--- a/tests/appSpecLint.test.ts
+++ b/tests/appSpecLint.test.ts
@@ -208,7 +208,7 @@ describe('lint_app_spec', () => {
     expect(body.errors.join(' ')).toMatch(/unknown.*target_ref/i);
     expect(body.errors.join(' ')).toMatch(/trigger "onChange" is not valid for Button/i);
     expect(body.warnings.join(' ')).toMatch(/order_filters|Unknown option key/i);
-    expect(body.errors.join(' ')).toMatch(/too short.*single line needs/i);
+    expect(body.errors.join(' ')).toMatch(/too short to render one line.*at least 54px/i);
   });
 
   it('requires at least one spec section', async () => {

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -41,7 +41,7 @@ describe('lintComponentSpec', () => {
     expect(r.warnings.join(' ')).toMatch(/native title defaults to a non-empty string that clips/);
   });
 
-  it('warns when a large Text is shorter than its line box plus wrapper chrome', () => {
+  it('blocks a large Text shorter than its line box plus wrapper chrome', () => {
     const title = {
       name: 'pageTitle',
       type: 'Text',
@@ -54,7 +54,7 @@ describe('lintComponentSpec', () => {
       layout: { top: 0, left: 2, width: 30, height: 40 },
     };
     expect(minimumTextHeight(title)).toBe(42);
-    expect(lintComponents([title]).warnings.join(' ')).toMatch(
+    expect(lintComponents([title]).errors.join(' ')).toMatch(
       /Text "pageTitle" is too short.*height 40px.*at least 42px.*use 50px.*descenders are clipped/i
     );
 
@@ -689,6 +689,12 @@ describe('lintComponentSpec', () => {
   });
 
   it('warns when a static-height Table cannot show rowsPerPage without inner scrolling', () => {
+    const unusable = lintComponentSpec({
+      name: 'orders', type: 'Table', properties: { rowsPerPage: { value: '{{10}}' } },
+      layout: { top: 0, left: 0, width: 30, height: 60 },
+    });
+    expect(unusable.errors.join(' ')).toMatch(/cannot show even one data row/i);
+
     const compact = lintComponentSpec({
       name: 'orders',
       type: 'Table',
@@ -1143,7 +1149,7 @@ describe('lintComponents (batch)', () => {
   it('aggregates per-component results and overlaps', () => {
     const { errors, warnings } = lintComponents([
       { name: 'chart', type: 'Chart', properties: {}, layout: { top: 0, left: 0, width: 10, height: 10 } },
-      { name: 'over', type: 'Text', properties: {}, layout: { top: 5, left: 5, width: 10, height: 10 } },
+      { name: 'over', type: 'Text', properties: {}, layout: { top: 5, left: 5, width: 10, height: 30 } },
     ]);
     expect(errors).toEqual([]);
     expect(warnings.join(' ')).toMatch(/native title/);

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -41,7 +41,7 @@ describe('lintComponentSpec', () => {
     expect(r.warnings.join(' ')).toMatch(/native title defaults to a non-empty string that clips/);
   });
 
-  it('blocks a large Text shorter than its line box plus wrapper chrome', () => {
+  it('warns for wrapper chrome shortfall but blocks a clipped line box', () => {
     const title = {
       name: 'pageTitle',
       type: 'Text',
@@ -54,9 +54,13 @@ describe('lintComponentSpec', () => {
       layout: { top: 0, left: 2, width: 30, height: 40 },
     };
     expect(minimumTextHeight(title)).toBe(42);
-    expect(lintComponents([title]).errors.join(' ')).toMatch(
+    expect(lintComponents([title]).errors).toEqual([]);
+    expect(lintComponents([title]).warnings.join(' ')).toMatch(
       /Text "pageTitle" is too short.*height 40px.*at least 42px.*use 50px.*descenders are clipped/i
     );
+
+    expect(lintComponents([{ ...title, layout: { ...title.layout, height: 30 } }]).errors.join(' '))
+      .toMatch(/too short to render one line.*at least 42px/i);
 
     expect(lintComponents([{ ...title, layout: { ...title.layout, height: 50 } }]).warnings).toEqual([]);
     expect(lintComponents([{

--- a/tests/queryExecutionSafety.test.ts
+++ b/tests/queryExecutionSafety.test.ts
@@ -142,6 +142,16 @@ describe('query execution safety', () => {
     })).toMatchObject({ provenRead: false, directSafe: false });
   });
 
+  it('classifies bounded Supabase row reads without treating writes as reads', () => {
+    expect(assessQueryRead({
+      id: 'sb-read', kind: 'supabase', data_source_id: 'sb1',
+      options: { operation: 'get_rows', get_table_name: 'deployments', get_limit: 25 },
+    })).toMatchObject({ provenRead: true, requiresRemoteReadConfirmation: true, maxRows: 25 });
+    expect(assessQueryRead({
+      id: 'sb-write', kind: 'supabase', options: { operation: 'insert_row', insert_table_name: 'deployments' },
+    })).toMatchObject({ provenRead: false });
+  });
+
   it('extracts only an unambiguous one-row numeric count', () => {
     expect(extractRowCount({ status: 'ok', data: [{ total: '2400' }] })).toBe(2400);
     expect(extractRowCount({ status: 'ok', data: [{ total: 20, other: 2 }] })).toBeUndefined();

--- a/tests/queryExecutionSafety.test.ts
+++ b/tests/queryExecutionSafety.test.ts
@@ -79,6 +79,10 @@ describe('query execution safety', () => {
       id: 'filtered', kind: 'postgresql', data_source_id: 'pg-main',
       options: { query: 'SELECT COUNT(*) FROM orders WHERE id = -1' },
     });
+    const dynamic = assessQueryRead({
+      id: 'dynamic', kind: 'supabase', data_source_id: 'sb1',
+      options: { operation: 'count_rows', count_table_name: 'deployments', count_filters: '{{variables.filters}}' },
+    });
     const otherDatasource = assessQueryRead({
       id: 'other', kind: 'postgresql', data_source_id: 'pg-replica',
       options: { query: 'SELECT COUNT(*) FROM orders' },
@@ -94,6 +98,8 @@ describe('query execution safety', () => {
 
     expect(filtered.fullSourceCount).toBe(false);
     expect(sameReadSource(target, filtered)).toBe(false);
+    expect(dynamic.fullSourceCount).toBe(false);
+    expect(sameReadSource(target, dynamic)).toBe(false);
     expect(sameReadSource(target, otherDatasource)).toBe(false);
     expect(sameReadSource(joinedTarget, fullCount)).toBe(false);
   });
@@ -150,6 +156,29 @@ describe('query execution safety', () => {
     expect(assessQueryRead({
       id: 'sb-write', kind: 'supabase', options: { operation: 'insert_row', insert_table_name: 'deployments' },
     })).toMatchObject({ provenRead: false });
+    expect(assessQueryRead({
+      id: 'sb-dynamic', kind: 'supabase',
+      options: { operation: 'get_rows', get_table_name: '{{components.table.value}}', get_limit: 25 },
+    })).toMatchObject({ provenRead: false });
+  });
+
+  it('accepts only unfiltered Supabase counts as a full-source preflight', () => {
+    const target = assessQueryRead({
+      id: 'target', kind: 'supabase', data_source_id: 'sb1',
+      options: { operation: 'get_rows', get_table_name: 'deployments' },
+    });
+    const full = assessQueryRead({
+      id: 'count', kind: 'supabase', data_source_id: 'sb1',
+      options: { operation: 'count_rows', count_table_name: 'deployments', count_filters: [] },
+    });
+    const filtered = assessQueryRead({
+      id: 'filtered', kind: 'supabase', data_source_id: 'sb1',
+      options: { operation: 'count_rows', count_table_name: 'deployments', count_filters: [{ key: 'status' }] },
+    });
+    expect(full.fullSourceCount).toBe(true);
+    expect(sameReadSource(target, full)).toBe(true);
+    expect(filtered.fullSourceCount).toBe(false);
+    expect(sameReadSource(target, filtered)).toBe(false);
   });
 
   it('extracts only an unambiguous one-row numeric count', () => {

--- a/tests/reliabilityTools.test.ts
+++ b/tests/reliabilityTools.test.ts
@@ -111,6 +111,27 @@ describe('ToolJet DB maintenance tools', () => {
 });
 
 describe('update_components validation', () => {
+  it('refuses a style update that makes existing Text geometry unusable', async () => {
+    const client = {
+      getAppSummary: vi.fn().mockResolvedValue({
+        app_id: 'app1',
+        pages: [{ id: 'p1', components: [{
+          id: 'title', name: 'title', type: 'Text', properties: {}, styles: {},
+          layouts: { desktop: { top: 0, left: 0, width: 20, height: 40 } },
+        }] }],
+        queries: [], events: [],
+      }),
+      updateComponents: vi.fn(),
+    } as unknown as ToolJetClient;
+    const result = await updateComponentsTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      updates: [{ component_id: 'title', definition: { styles: { textSize: 32, lineHeight: 1.5 } } }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/too short to render one line/i);
+    expect(client.updateComponents).not.toHaveBeenCalled();
+  });
+
   // Regression: models pass the component NAME as component_id (it is the handle they authored and
   // what bindings use). Looking up by id only and answering "does not exist" made the model re-read
   // the page, see the component, and retry forever — >1M tokens on one observed build.
@@ -152,6 +173,23 @@ describe('update_components validation', () => {
     const body = result.content[0]!.text;
     expect(body).toContain('realOne=c1');
     expect(client.updateComponents).not.toHaveBeenCalled();
+  });
+
+  it('allows renaming a component that already has unrelated lint errors', async () => {
+    const client = {
+      getAppSummary: vi.fn().mockResolvedValue({
+        app_id: 'app1',
+        pages: [{ id: 'p1', components: [{ id: 'legacy', name: 'oldName', type: '', properties: {} }] }],
+        queries: [], events: [],
+      }),
+      updateComponents: vi.fn().mockResolvedValue({ updated: 1 }),
+    } as unknown as ToolJetClient;
+    const result = await updateComponentsTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      updates: [{ component_id: 'legacy', name: 'newName' }],
+    });
+    expect(result.isError).not.toBe(true);
+    expect(client.updateComponents).toHaveBeenCalledOnce();
   });
 
   it('canonicalizes concise raw definition leaves before an update', async () => {
@@ -322,11 +360,11 @@ describe('update_components validation', () => {
         pages: [{ id: 'p1', components: [
           {
             id: 'first', name: 'first', type: 'TextInput', properties: { label: { value: 'First' } },
-            styles: { alignment: { value: 'side' } }, layouts: { desktop: { top: 0, left: 0, width: 18, height: 62 } },
+            styles: { alignment: { value: 'side' } }, layouts: { desktop: { top: 0, left: 0, width: 18, height: 40 } },
           },
           {
             id: 'second', name: 'second', type: 'TextInput', properties: { label: { value: 'Second' } },
-            styles: { alignment: { value: 'side' } }, layouts: { desktop: { top: 72, left: 0, width: 18, height: 62 } },
+            styles: { alignment: { value: 'side' } }, layouts: { desktop: { top: 50, left: 0, width: 18, height: 40 } },
           },
         ] }],
         queries: [],
@@ -338,7 +376,7 @@ describe('update_components validation', () => {
       app_id: 'app1', version_id: 'v1', page_id: 'p1',
       updates: [{ component_id: 'first', definition: { styles: { alignment: { value: 'top' } } } }],
     });
-    expect(textOf(result).warnings.join(' ')).toMatch(/renders 82px tall.*authored 62px \+ 20px/);
+    expect(textOf(result).warnings.join(' ')).toMatch(/renders 60px tall.*authored 40px \+ 20px/);
     expect(client.updateComponents).toHaveBeenCalled();
   });
 });
@@ -373,11 +411,11 @@ describe('update_layout geometry warnings', () => {
         pages: [{ id: 'p1', components: [
           {
             id: 'first', name: 'first', type: 'TextInput', properties: { label: { value: 'First' } },
-            styles: { alignment: { value: 'top' } }, layouts: { desktop: { top: 0, left: 0, width: 18, height: 62 } },
+            styles: { alignment: { value: 'top' } }, layouts: { desktop: { top: 0, left: 0, width: 18, height: 40 } },
           },
           {
             id: 'second', name: 'second', type: 'TextInput', properties: { label: { value: 'Second' } },
-            styles: { alignment: { value: 'top' } }, layouts: { desktop: { top: 100, left: 0, width: 18, height: 62 } },
+            styles: { alignment: { value: 'top' } }, layouts: { desktop: { top: 100, left: 0, width: 18, height: 40 } },
           },
         ] }],
         queries: [],
@@ -387,7 +425,7 @@ describe('update_layout geometry warnings', () => {
     } as unknown as ToolJetClient;
     const result = await updateLayoutTool(client).handler({
       app_id: 'app1', version_id: 'v1', page_id: 'p1',
-      layouts: [{ component_id: 'second', desktop: { top: 72, left: 0, width: 18, height: 62 } }],
+      layouts: [{ component_id: 'second', desktop: { top: 50, left: 0, width: 18, height: 40 } }],
     });
     expect(textOf(result).warnings.join(' ')).toMatch(/overlap at rendered desktop size/);
     expect(client.updateLayouts).toHaveBeenCalled();

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ToolJetClient } from '../src/tooljetClient.js';
+import { ToolJetHttpError, type ToolJetClient } from '../src/tooljetClient.js';
 import { testDatasourceConnectionTool } from '../src/tools/testDatasourceConnection.js';
 
 function textOf(result: { content: Array<{ text: string }> }): any {
@@ -46,7 +46,7 @@ describe('test_datasource_connection tool', () => {
     );
   });
 
-  it('reports an unsupported kind instead of a broken connection', async () => {
+  it('keeps an unstructured plugin failure inconclusive', async () => {
     const client = clientWith({
       testDatasourceConnection: vi
         .fn()
@@ -55,17 +55,16 @@ describe('test_datasource_connection tool', () => {
     const parsed = textOf(
       await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
     );
-    expect(parsed.supported).toBe(false);
-    expect(parsed.status).toBe('unsupported');
-    expect(parsed.message).toMatch(/does not implement a connection test/);
-    expect(parsed.recovery).toBeUndefined();
+    expect(parsed.supported).toBe(true);
+    expect(parsed.status).toBe('inconclusive');
+    expect(parsed.verification).toMatchObject({ requires_user_approval: true });
   });
 
   it('returns a repair handoff on a genuine connection failure', async () => {
     const client = clientWith({
       testDatasourceConnection: vi
         .fn()
-        .mockResolvedValue({ status: 'failed', message: 'connection refused\n        ' }),
+        .mockResolvedValue({ status: 'failed', category: 'connection', message: 'connection refused\n        ' }),
     });
     const parsed = textOf(
       await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
@@ -82,7 +81,7 @@ describe('test_datasource_connection tool', () => {
     const client = clientWith({
       testDatasourceConnection: vi
         .fn()
-        .mockRejectedValue(new Error('ToolJet testDatasourceConnection failed (403): Forbidden')),
+        .mockRejectedValue(new ToolJetHttpError(403, 'testDatasourceConnection', 'Forbidden')),
     });
     const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
     expect(result.isError).toBeUndefined();

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -132,16 +132,45 @@ describe('test_datasource_connection tool', () => {
     expect(parsed.verification).toMatchObject({ requires_user_approval: true });
   });
 
-  it('does not mistake connection-detail permissions for a broken or unsupported datasource', async () => {
+  it.each([401, 403, 500])('keeps a %i connection-detail failure as an MCP error', async (status) => {
     const client = clientWith({
       getDatasourceConnectionDetails: vi
         .fn()
-        .mockRejectedValue(new ToolJetHttpError(403, 'getDatasourceConnectionDetails', 'Forbidden')),
+        .mockRejectedValue(new ToolJetHttpError(status, 'getDatasourceConnectionDetails', 'Request failed')),
     });
-    const parsed = textOf(
-      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
-    );
-    expect(parsed.status).toBe('inconclusive');
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain(`failed (${status})`);
+    expect(client.testDatasourceConnection).not.toHaveBeenCalled();
+  });
+
+  it.each([404, 501])('reports a %i from the test endpoint as unsupported', async (status) => {
+    const client = clientWith({
+      testDatasourceConnection: vi
+        .fn()
+        .mockRejectedValue(new ToolJetHttpError(status, 'testDatasourceConnection', 'Unavailable')),
+    });
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBeUndefined();
+    expect(textOf(result)).toMatchObject({ status: 'unsupported', supported: false });
+  });
+
+  it.each([401, 408, 429, 500])('keeps a %i test-endpoint failure as an MCP error', async (status) => {
+    const client = clientWith({
+      testDatasourceConnection: vi
+        .fn()
+        .mockRejectedValue(new ToolJetHttpError(status, 'testDatasourceConnection', 'Request failed')),
+    });
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain(`failed (${status})`);
+  });
+
+  it('keeps a transport failure as an MCP error', async () => {
+    const client = clientWith({ testDatasourceConnection: vi.fn().mockRejectedValue(new Error('fetch failed')) });
+    const result = await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('Error: fetch failed');
   });
 
   it('rejects a datasource that is not on this version', async () => {

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -60,6 +60,22 @@ describe('test_datasource_connection tool', () => {
     expect(parsed.recovery).toMatchObject({ action: 'open_datasource_settings' });
   });
 
+  it('uses ToolJet structured metadata when a plugin does not implement a connection test', async () => {
+    const client = clientWith({
+      testDatasourceConnection: vi.fn().mockResolvedValue({
+        status: 'failed',
+        category: 'unsupported',
+        supported: false,
+        message: 'opaque server text',
+      }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed).toMatchObject({ status: 'unsupported', supported: false });
+    expect(parsed).not.toHaveProperty('recovery');
+  });
+
   it('returns a repair handoff on a genuine connection failure', async () => {
     const client = clientWith({
       testDatasourceConnection: vi

--- a/tests/testDatasourceConnection.test.ts
+++ b/tests/testDatasourceConnection.test.ts
@@ -46,7 +46,7 @@ describe('test_datasource_connection tool', () => {
     );
   });
 
-  it('keeps an unstructured plugin failure inconclusive', async () => {
+  it('trusts a failed verdict when the catalog confirms the plugin supports the test', async () => {
     const client = clientWith({
       testDatasourceConnection: vi
         .fn()
@@ -56,15 +56,15 @@ describe('test_datasource_connection tool', () => {
       await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
     );
     expect(parsed.supported).toBe(true);
-    expect(parsed.status).toBe('inconclusive');
-    expect(parsed.verification).toMatchObject({ requires_user_approval: true });
+    expect(parsed.status).toBe('failed');
+    expect(parsed.recovery).toMatchObject({ action: 'open_datasource_settings' });
   });
 
   it('returns a repair handoff on a genuine connection failure', async () => {
     const client = clientWith({
       testDatasourceConnection: vi
         .fn()
-        .mockResolvedValue({ status: 'failed', category: 'connection', message: 'connection refused\n        ' }),
+        .mockResolvedValue({ status: 'failed', message: 'connection refused\n        ' }),
     });
     const parsed = textOf(
       await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
@@ -116,6 +116,32 @@ describe('test_datasource_connection tool', () => {
     // An undefined flag is a stale catalog, not a claim that the plugin lacks the method.
     expect(client.testDatasourceConnection).toHaveBeenCalled();
     expect(parsed.status).toBe('ok');
+  });
+
+  it('keeps a failed result inconclusive when the catalog cannot prove test support', async () => {
+    const client = clientWith({
+      listDatasources: vi.fn().mockResolvedValue([
+        { id: 'x1', name: 'Unlisted', kind: 'not-in-the-catalog', settings_url: 'http://tj/ws/data-sources/x1' },
+      ]),
+      testDatasourceConnection: vi.fn().mockResolvedValue({ status: 'failed', message: 'unknown result' }),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'x1' })
+    );
+    expect(parsed.status).toBe('inconclusive');
+    expect(parsed.verification).toMatchObject({ requires_user_approval: true });
+  });
+
+  it('does not mistake connection-detail permissions for a broken or unsupported datasource', async () => {
+    const client = clientWith({
+      getDatasourceConnectionDetails: vi
+        .fn()
+        .mockRejectedValue(new ToolJetHttpError(403, 'getDatasourceConnectionDetails', 'Forbidden')),
+    });
+    const parsed = textOf(
+      await testDatasourceConnectionTool(client).handler({ version_id: 'v1', datasource_id: 'pg1' })
+    );
+    expect(parsed.status).toBe('inconclusive');
   });
 
   it('rejects a datasource that is not on this version', async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -228,6 +228,54 @@ describe('run_query tool', () => {
     });
   });
 
+  it('preserves a completed count preflight when the target transport throws', async () => {
+    const client = makeClient();
+    client.getQuery
+      .mockResolvedValueOnce({
+        id: 'rows', name: 'listOrders', kind: 'postgresql', data_source_id: 'pg-main',
+        options: { mode: 'sql', query: 'SELECT id, status FROM orders' },
+      })
+      .mockResolvedValueOnce({
+        id: 'count', name: 'countOrders', kind: 'postgresql', data_source_id: 'pg-main',
+        options: { mode: 'sql', query: 'SELECT COUNT(*) AS total FROM orders' },
+      });
+    client.runQuery
+      .mockResolvedValueOnce({ status: 'ok', data: [{ total: 48 }] })
+      .mockRejectedValueOnce(new Error('socket closed'));
+
+    const result = await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'rows', count_query_id: 'count', version_id: 'v1',
+    });
+
+    expect(textOf(result)).toMatchObject({
+      status: 'failed', message: 'socket closed',
+      preflight: { count_query_id: 'count', row_count: 48, threshold: 1000 },
+    });
+  });
+
+  it('runs an approved Supabase count preflight before an unbounded Supabase read', async () => {
+    const client = makeClient();
+    client.getQuery
+      .mockResolvedValueOnce({
+        id: 'rows', kind: 'supabase', data_source_id: 'sb-main',
+        options: { operation: 'get_rows', get_table_name: 'deployments' },
+      })
+      .mockResolvedValueOnce({
+        id: 'count', kind: 'supabase', data_source_id: 'sb-main',
+        options: { operation: 'count_rows', count_table_name: 'deployments', count_filters: [] },
+      });
+    client.runQuery
+      .mockResolvedValueOnce({ status: 'ok', data: [{ count: 48 }] })
+      .mockResolvedValueOnce({ status: 'ok', data: [{ id: 1 }] });
+
+    const result = await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'rows', count_query_id: 'count', version_id: 'v1', user_confirmed_remote_read: true,
+    });
+
+    expect(client.runQuery).toHaveBeenCalledTimes(2);
+    expect(textOf(result)).toMatchObject({ status: 'ok', preflight: { row_count: 48 } });
+  });
+
   it('reports the observed large count and requires explicit user confirmation before the target run', async () => {
     const client = makeClient();
     client.getQuery

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -170,7 +170,7 @@ describe('run_query tool', () => {
       datasource_settings_url: 'http://localhost:8082/acme/data-sources/pg1',
       options: { mode: 'sql', query: 'select id from orders limit 25' },
     });
-    client.runQuery.mockResolvedValue({ status: 'failed', message: 'connection refused' });
+    client.runQuery.mockResolvedValue({ status: 'failed', data: { code: '08006' }, message: 'connection refused' });
 
     const result = await runQueryTool(client as unknown as ToolJetClient).handler({
       query_id: 'q1', version_id: 'v1',
@@ -393,11 +393,6 @@ describe('run_queries tool', () => {
       {
         query_id: 'q2', name: 'page', status: 'failed', message: 'connect ETIMEDOUT',
         warnings: [expect.stringMatching(/components\.\*.*viewer/i)],
-        recovery: {
-          action: 'open_datasource_settings',
-          url: 'http://localhost:8082/acme/data-sources/tjdb',
-          instruction: expect.stringMatching(/user.*in-app browser.*do not enter credentials/is),
-        },
       },
     ] });
   });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1296,7 +1296,7 @@ describe('add_component tool', () => {
       name: 't',
       type: 'Table',
       properties: { data: { value: '{{queries.q.data}}' } },
-      layout: { top: 0, left: 0, width: 10, height: 5 },
+      layout: { top: 0, left: 0, width: 10, height: 300 },
     });
     expect(client.createComponent).toHaveBeenCalled(); // not blocked
     const out = textOf(result) as { component_id: string; warnings: string[] };
@@ -1354,7 +1354,7 @@ describe('add_component tool', () => {
       name: 'title',
       type: 'Text',
       properties: { textColor: { value: '#111' } },
-      layout: { top: 0, left: 0, width: 10, height: 4 },
+      layout: { top: 0, left: 0, width: 10, height: 30 },
     });
     expect(result.isError).toBeUndefined();
     expect(client.createComponent).toHaveBeenCalledOnce();

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -186,6 +186,62 @@ describe('run_query tool', () => {
     });
   });
 
+  it.each([
+    ['MySQL', { status: 'failed', category: 'authentication', data: { code: 'ER_ACCESS_DENIED_ERROR', sqlState: '28000' } }],
+    ['MSSQL', { status: 'failed', category: 'connection', data: { code: 'ESOCKET' } }],
+    ['MongoDB', { status: 'failed', category: 'connection', data: { name: 'MongoNetworkError' } }],
+    ['REST', { status: 'failed', category: 'authentication', data: { responseObject: { statusCode: 401 } } }],
+  ])('uses ToolJet structured recovery for %s failures', async (_kind, failure) => {
+    const client = makeClient();
+    client.getQuery.mockResolvedValue({
+      id: 'q1', kind: 'postgresql', data_source_id: 'ds1',
+      datasource_settings_url: 'http://localhost:8082/acme/data-sources/ds1',
+      options: { mode: 'sql', query: 'select id from orders limit 25' },
+    });
+    client.runQuery.mockResolvedValue(failure);
+
+    const result = await runQueryTool(client as unknown as ToolJetClient).handler({ query_id: 'q1', version_id: 'v1' });
+    expect(textOf(result)).toMatchObject({
+      status: 'failed',
+      recovery: { action: 'open_datasource_settings' },
+    });
+  });
+
+  it.each([
+    [{ code: 'ER_ACCESS_DENIED_ERROR', sqlState: '28000' }, 'connection'],
+    [{ code: 'ELOGIN' }, 'connection'],
+    [{ code: 'ER_NO_SUCH_TABLE' }, 'schema_name'],
+  ])('supports older servers using structured driver fields %o', async (data, expected) => {
+    const client = makeClient();
+    client.getQuery.mockResolvedValue({
+      id: 'q1', kind: 'mysql', data_source_id: 'ds1',
+      datasource_settings_url: 'http://localhost:8082/acme/data-sources/ds1',
+      options: { mode: 'sql', query: 'select id from orders limit 25' },
+    });
+    client.runQuery.mockResolvedValue({ status: 'failed', data });
+
+    const parsed = textOf(await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'q1', version_id: 'v1',
+    }));
+    if (expected === 'connection') expect(parsed.recovery).toMatchObject({ action: 'open_datasource_settings' });
+    else expect(parsed.schema_hint).toMatchObject({ kind: 'schema_name_error' });
+  });
+
+  it('requires verification for a structurally unknown failure instead of guessing', async () => {
+    const client = makeClient();
+    client.getQuery.mockResolvedValue({
+      id: 'q1', kind: 'postgresql', data_source_id: 'ds1',
+      options: { mode: 'sql', query: 'select id from orders limit 25' },
+    });
+    client.runQuery.mockResolvedValue({ status: 'failed', category: 'unknown', message: 'opaque failure' });
+
+    const parsed = textOf(await runQueryTool(client as unknown as ToolJetClient).handler({
+      query_id: 'q1', version_id: 'v1',
+    }));
+    expect(parsed).not.toHaveProperty('recovery');
+    expect(parsed.verification).toMatchObject({ action: 'test_datasource_connection', datasource_id: 'ds1' });
+  });
+
   it('refuses SELECT star before execution, even when it has a limit', async () => {
     const client = makeClient();
     client.getQuery.mockResolvedValue({

--- a/tests/updateLayoutRefs.test.ts
+++ b/tests/updateLayoutRefs.test.ts
@@ -14,7 +14,7 @@ describe('update_layout ref resolution', () => {
     const c = client([{ id: 'uuid-1', name: 'hiresTable', type: 'Table', properties: {}, styles: {}, layouts: {} }]);
     const result: any = await updateLayoutTool(c).handler({
       app_id: 'app1', version_id: 'v1', page_id: 'p1',
-      layouts: [{ component_id: 'hiresTable', desktop: { top: 0, left: 0, width: 10, height: 4 } }],
+      layouts: [{ component_id: 'hiresTable', desktop: { top: 0, left: 0, width: 10, height: 620 } }],
     });
     expect(result.isError).not.toBe(true);
     expect((c as any).updateLayouts).toHaveBeenCalledWith(
@@ -30,5 +30,50 @@ describe('update_layout ref resolution', () => {
     });
     expect(result.content[0].text).toContain('realOne=uuid-1');
     expect((c as any).updateLayouts).not.toHaveBeenCalled();
+  });
+
+  it('refuses a resize that makes text unable to render one line', async () => {
+    const c = client([{
+      id: 'title', name: 'title', type: 'Text', properties: {},
+      styles: { textSize: { value: 24 }, lineHeight: { value: 1.5 } },
+      layouts: { desktop: { top: 0, left: 0, width: 20, height: 50 } },
+    }]);
+    const result: any = await updateLayoutTool(c).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      layouts: [{ component_id: 'title', desktop: { top: 0, left: 0, width: 20, height: 30 } }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/too short to render one line/i);
+    expect((c as any).updateLayouts).not.toHaveBeenCalled();
+  });
+
+  it('allows a pure move when the component already has an unrelated lint error', async () => {
+    const c = client([{
+      id: 'legacy', name: 'legacy', type: '', properties: {},
+      layouts: { desktop: { top: 0, left: 0, width: 20, height: 40 } },
+    }]);
+    const result: any = await updateLayoutTool(c).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      layouts: [{ component_id: 'legacy', desktop: { top: 50, left: 0, width: 20, height: 40 } }],
+    });
+    expect(result.isError).not.toBe(true);
+    expect((c as any).updateLayouts).toHaveBeenCalledOnce();
+  });
+
+  it('does not apply an untouched mobile Text error to a desktop-only move', async () => {
+    const c = client([{
+      id: 'title', name: 'title', type: 'Text', properties: {},
+      styles: { textSize: { value: 24 }, lineHeight: { value: 1.5 } },
+      layouts: {
+        desktop: { top: 0, left: 0, width: 20, height: 50 },
+        mobile: { top: 0, left: 0, width: 20, height: 20 },
+      },
+    }]);
+    const result: any = await updateLayoutTool(c).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      layouts: [{ component_id: 'title', desktop: { top: 50, left: 0, width: 20, height: 50 } }],
+    });
+    expect(result.isError).not.toBe(true);
+    expect((c as any).updateLayouts).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Fixes
- Reports datasource connectivity as connected, disconnected, or inconclusive.
- Supports a user-approved bounded read when metadata alone cannot prove connectivity.
- Makes broken component geometry block generation instead of remaining a warning.
- Removes the Grok-only combined 10k reference cap while retaining per-document section limits.

## Performance impact
- Geometry validation is local and negligible.
- A connection probe is bounded and runs only after approval.
- Grok may receive more relevant reference context than before, with a modest prompt-size increase capped per document.

## Integrated source
- #26