### PR TITLE
manage_theme create: deterministic fallback when custom themes are no…

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -43223,6 +43223,7 @@ function getRuntimeInfoTool(runtime) {
 }
 
 // dist/tools/manageTheme.js
+var THEME_LICENCE_USER_MESSAGE = "Custom themes are not included in your current ToolJet plan, so this app uses the workspace default theme. Upgrading your plan enables branded themes; the app can be re-themed in one request afterwards.";
 var colorPair = external_exports.object({
   light: external_exports.string().trim().min(1).max(100).describe("Color used in light mode; hex is recommended."),
   dark: external_exports.string().trim().min(1).max(100).describe("Color used in dark mode; hex is recommended.")
@@ -43333,12 +43334,26 @@ function manageThemeTool(client) {
               ]
             });
           }
-          const created = await client.createAppTheme({
-            name,
-            definition: requireValue(args.definition, "definition"),
-            isDefault: args.is_default ?? false
-          });
-          return ok({ theme: created });
+          try {
+            const created = await client.createAppTheme({
+              name,
+              definition: requireValue(args.definition, "definition"),
+              isDefault: args.is_default ?? false
+            });
+            return ok({ theme: created });
+          } catch (error51) {
+            if (error51 instanceof ToolJetHttpError && error51.status === 451) {
+              return ok({
+                theme: null,
+                licensed: false,
+                user_message: THEME_LICENCE_USER_MESSAGE,
+                warnings: [
+                  "Custom themes are not included in this ToolJet plan (HTTP 451). The app keeps the workspace default theme. Do not retry theme creation or guess a theme id; build the app on the default theme and repeat `user_message` to the user in the closing handoff."
+                ]
+              });
+            }
+            throw error51;
+          }
         }
         const themeId = requireValue(args.theme_id, "theme_id");
         await readTheme(client, themeId);

--- a/docs/theme-api-tool.md
+++ b/docs/theme-api-tool.md
@@ -70,6 +70,11 @@ Theming is part of building an app from scratch, and of nothing else.
   create, change or apply a theme, do not touch app settings, and style what you add to match what is already
   there. The app's current theme is the user's decision, not yours.
 
+**Licence gate.** Custom themes are a licensed feature. When `manage_theme` create returns `licensed: false`
+(the instance answered HTTP 451), the app stays on the workspace default theme: do not retry under another name
+or guess a theme id, build on the default, and repeat the result's `user_message` to the user in the closing
+handoff so they know their plan does not include custom themes and that upgrading enables them.
+
 ## Derive a theme from the request (do this before `create_app`)
 
 The user does not have to ask for a theme. If the request says who the app is for, the customer has an expectation

--- a/skill/references/themes.md
+++ b/skill/references/themes.md
@@ -70,6 +70,11 @@ Theming is part of building an app from scratch, and of nothing else.
   create, change or apply a theme, do not touch app settings, and style what you add to match what is already
   there. The app's current theme is the user's decision, not yours.
 
+**Licence gate.** Custom themes are a licensed feature. When `manage_theme` create returns `licensed: false`
+(the instance answered HTTP 451), the app stays on the workspace default theme: do not retry under another name
+or guess a theme id, build on the default, and repeat the result's `user_message` to the user in the closing
+handoff so they know their plan does not include custom themes and that upgrading enables them.
+
 ## Derive a theme from the request (do this before `create_app`)
 
 The user does not have to ask for a theme. If the request says who the app is for, the customer has an expectation

--- a/skills/tooljet-app-builder/references/themes.md
+++ b/skills/tooljet-app-builder/references/themes.md
@@ -70,6 +70,11 @@ Theming is part of building an app from scratch, and of nothing else.
   create, change or apply a theme, do not touch app settings, and style what you add to match what is already
   there. The app's current theme is the user's decision, not yours.
 
+**Licence gate.** Custom themes are a licensed feature. When `manage_theme` create returns `licensed: false`
+(the instance answered HTTP 451), the app stays on the workspace default theme: do not retry under another name
+or guess a theme id, build on the default, and repeat the result's `user_message` to the user in the closing
+handoff so they know their plan does not include custom themes and that upgrading enables them.
+
 ## Derive a theme from the request (do this before `create_app`)
 
 The user does not have to ask for a theme. If the request says who the app is for, the customer has an expectation

--- a/src/tools/manageTheme.ts
+++ b/src/tools/manageTheme.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import type { AppTheme, ToolJetClient } from '../tooljetClient.js';
+import { ToolJetHttpError, type AppTheme, type ToolJetClient } from '../tooljetClient.js';
+
+/** Shown to the end user, verbatim, when the instance's plan has no custom-themes feature. */
+export const THEME_LICENCE_USER_MESSAGE =
+  'Custom themes are not included in your current ToolJet plan, so this app uses the workspace default theme. ' +
+  'Upgrading your plan enables branded themes; the app can be re-themed in one request afterwards.';
 import { fail, ok, type ToolDef } from './types.js';
 
 const colorPair = z.object({
@@ -133,12 +138,32 @@ export function manageThemeTool(client: ToolJetClient): ToolDef {
               ],
             });
           }
-          const created = await client.createAppTheme({
-            name,
-            definition: requireValue(args.definition, 'definition'),
-            isDefault: args.is_default ?? false,
-          });
-          return ok({ theme: created });
+          try {
+            const created = await client.createAppTheme({
+              name,
+              definition: requireValue(args.definition, 'definition'),
+              isDefault: args.is_default ?? false,
+            });
+            return ok({ theme: created });
+          } catch (error) {
+            // Custom themes are a licensed feature; Community Edition answers 451. That is a fact about
+            // the customer's plan, not a mistake in the call, so it must not read as an error the model
+            // should repair (retrying under another name, guessing a theme id). Return a plain result
+            // that says what happened and what to tell the user.
+            if (error instanceof ToolJetHttpError && error.status === 451) {
+              return ok({
+                theme: null,
+                licensed: false,
+                user_message: THEME_LICENCE_USER_MESSAGE,
+                warnings: [
+                  'Custom themes are not included in this ToolJet plan (HTTP 451). The app keeps the workspace ' +
+                    'default theme. Do not retry theme creation or guess a theme id; build the app on the default ' +
+                    'theme and repeat `user_message` to the user in the closing handoff.',
+                ],
+              });
+            }
+            throw error;
+          }
         }
 
         const themeId = requireValue(args.theme_id, 'theme_id');

--- a/tests/manageTheme.test.ts
+++ b/tests/manageTheme.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolJetHttpError, type ToolJetClient } from '../src/tooljetClient.js';
+import { manageThemeTool, THEME_LICENCE_USER_MESSAGE } from '../src/tools/manageTheme.js';
+
+const definition = {
+  brand: { colors: { primary: { light: '#2563EB', dark: '#3B82F6' } } },
+  text: { font: 'Inter', colors: { primary: { light: '#111827', dark: '#F9FAFB' } } },
+  border: { radius: { default: 8, small: 6, large: 12 }, colors: { default: { light: '#E5E7EB', dark: '#374151' } } },
+  systemStatus: { colors: { success: { light: '#16A34A', dark: '#4ADE80' } } },
+  surface: {
+    colors: {
+      appBackground: { light: '#F9FAFB', dark: '#111827' },
+      surface1: { light: '#FFFFFF', dark: '#1F2937' },
+      surface2: { light: '#F3F4F6', dark: '#111827' },
+      surface3: { light: '#E5E7EB', dark: '#0B1220' },
+    },
+  },
+};
+
+function textOf(result: { content: Array<{ text: string }> }): any {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe('manage_theme create on an unlicensed instance', () => {
+  it('returns a plain result with the user-facing message instead of an error', async () => {
+    const client = {
+      listAppThemes: vi.fn().mockResolvedValue([]),
+      createAppTheme: vi.fn().mockRejectedValue(new ToolJetHttpError(451, 'createAppTheme', 'Feature not licensed')),
+    } as unknown as ToolJetClient;
+    const result = await manageThemeTool(client).handler({ action: 'create', name: 'Acme Ops theme', definition } as never);
+    expect(result.isError).toBeFalsy();
+    const body = textOf(result);
+    expect(body.theme).toBeNull();
+    expect(body.licensed).toBe(false);
+    expect(body.user_message).toBe(THEME_LICENCE_USER_MESSAGE);
+    expect(body.warnings.join(' ')).toMatch(/Do not retry theme creation/);
+  });
+
+  it('still surfaces other failures as errors', async () => {
+    const client = {
+      listAppThemes: vi.fn().mockResolvedValue([]),
+      createAppTheme: vi.fn().mockRejectedValue(new ToolJetHttpError(500, 'createAppTheme', 'boom')),
+    } as unknown as ToolJetClient;
+    const result = await manageThemeTool(client).handler({ action: 'create', name: 'Acme Ops theme', definition } as never);
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
…t licensed

Community Edition answers 451 to POST /api/themes. That surfaced as a plain error, and what the model did next (retry under another name, guess a theme id, give up) varied by run. create now returns a normal result with theme:null, licensed:false, a user_message telling the customer their plan does not include custom themes and that upgrading enables them, and a warning that says not to retry. create_app already handled the gate this way; the in-product path goes through manage_theme and did not.

themes.md carries the same rule so every host builds on the default theme and repeats the message in its handoff.