### PR TITLE
fix: stop failing builds on inherited misplaced style keys

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -34229,7 +34229,7 @@ function lintDesktopCanvasCoverage(components) {
     `Desktop page content spans only columns ${left}-${right} of ToolJet's 43-column canvas despite having multiple operational/analytical surfaces. This often produces an accidental half-width app. Expand the main composition toward the standard columns 2-41, or browser-verify that the narrow rail is deliberate.`
   ];
 }
-function lintComponentSpec(spec) {
+function lintComponentSpec(spec, options2 = {}) {
   const errors = [];
   const warnings = [];
   const props = spec.properties ?? {};
@@ -34243,7 +34243,9 @@ function lintComponentSpec(spec) {
     }
   }
   const misplaced = Object.keys(props).filter((k) => STYLE_KEYS_IN_PROPERTIES.has(k));
-  if (misplaced.length) {
+  if (misplaced.length && options2.persisted) {
+    warnings.push(`Component "${label}": style keys ${JSON.stringify(misplaced)} are stored under \`properties\`, where ToolJet ignores them. They are inert leftovers and cannot be removed by an update (ToolJet merges component definitions and cannot delete keys) \u2014 do not attempt to repair this. Set styling on \`styles\` instead; delete and recreate the component only if the user asks for it.`);
+  } else if (misplaced.length) {
     errors.push(`Component "${label}": style keys ${JSON.stringify(misplaced)} are under \`properties\`, where ToolJet ignores them \u2014 move them to the top-level \`styles\` object.`);
   }
   const rects = [spec.layout, spec.layouts?.desktop, spec.layouts?.mobile].filter(Boolean);
@@ -34361,13 +34363,13 @@ function lintComponentSpec(spec) {
   if (spec.type === "DropdownV2") {
     const advanced = propVal(props, "advanced");
     const schema = propVal(props, "schema");
-    const options2 = propVal(props, "options");
+    const options3 = propVal(props, "options");
     const customSchema = differsFromCatalogDefault("DropdownV2", "schema", schema);
-    const customOptions = differsFromCatalogDefault("DropdownV2", "options", options2);
-    if (customOptions && !Array.isArray(options2)) {
-      errors.push(`DropdownV2 "${label}": properties.options is static-array-only, but received ${typeof options2 === "string" && isDynamicBinding(options2) ? "a dynamic {{ }} binding" : typeof options2}. ToolJet can silently split a binding string into character objects. Use properties.schema with properties.advanced.value="{{true}}" for dynamic options, or pass a literal options array.`);
-    } else if (Array.isArray(options2)) {
-      const malformedIndexes = options2.flatMap((option, index) => {
+    const customOptions = differsFromCatalogDefault("DropdownV2", "options", options3);
+    if (customOptions && !Array.isArray(options3)) {
+      errors.push(`DropdownV2 "${label}": properties.options is static-array-only, but received ${typeof options3 === "string" && isDynamicBinding(options3) ? "a dynamic {{ }} binding" : typeof options3}. ToolJet can silently split a binding string into character objects. Use properties.schema with properties.advanced.value="{{true}}" for dynamic options, or pass a literal options array.`);
+    } else if (Array.isArray(options3)) {
+      const malformedIndexes = options3.flatMap((option, index) => {
         const entry = recordValue(option);
         return entry && "label" in entry && "value" in entry ? [] : [index];
       });
@@ -34883,7 +34885,7 @@ function validateAppStructure(summary) {
       styles: c.styles,
       layouts: c.layouts,
       parent: c.parent
-    });
+    }, { persisted: true });
     errors.push(...r.errors);
     warnings.push(...r.warnings);
   }
@@ -42091,7 +42093,11 @@ function updateComponentsTool(client) {
           if (update.definition)
             changedComponents.push({ before: current, after: normalizedNext });
           placementChanged ||= update.parent !== void 0 || update.slot_name !== void 0;
-          warnings.push(...normalized2.warnings);
+          const storedMisplaced = Object.keys(current.properties ?? {}).filter((key) => STYLE_KEYS_IN_PROPERTIES.has(key));
+          warnings.push(...normalized2.warnings.filter((warning) => !storedMisplaced.some((key) => warning.includes(`moved style key "${key}"`))));
+          if (storedMisplaced.length) {
+            warnings.push(`Component "${next.name}": style keys ${JSON.stringify(storedMisplaced)} were already stored under \`properties\` before this update and REMAIN there \u2014 component updates merge and cannot delete keys. Any new value you sent is applied to \`styles\` and renders correctly; the leftovers are inert. Do not retry this update to clear them, it cannot work.`);
+          }
           let normalizedDefinition = update.definition;
           if (update.definition && Object.keys(normalized2.patch).length) {
             normalizedDefinition = { ...update.definition };

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -857,8 +857,14 @@ export function lintDesktopCanvasCoverage(components: LintComponent[]): string[]
   ];
 }
 
-/** Lint a single component spec (pre-write). */
-export function lintComponentSpec(spec: LintComponent): LintResult {
+export interface LintComponentSpecOptions {
+  /** Reporting on an already-stored component rather than gating a write: findings that are inert
+   *  once persisted, and that no tool can repair, are warnings here so they cannot fail a build. */
+  persisted?: boolean;
+}
+
+/** Lint a single component spec (pre-write by default; pass `persisted` for an as-stored report). */
+export function lintComponentSpec(spec: LintComponent, options: LintComponentSpecOptions = {}): LintResult {
   const errors: string[] = [];
   const warnings: string[] = [];
   const props = spec.properties ?? {};
@@ -873,9 +879,19 @@ export function lintComponentSpec(spec: LintComponent): LintResult {
     }
   }
 
-  // ERROR: style keys under `properties` are silently dropped by ToolJet.
+  // ERROR pre-write (ToolJet drops these, so the styling is lost). Once persisted they are inert —
+  // the component still renders, since new values are normalized into `styles` — and unremovable,
+  // because ToolJet merges component updates and cannot delete keys. Erroring there fails builds over
+  // damage the agent neither caused nor can fix.
   const misplaced = Object.keys(props).filter((k) => STYLE_KEYS_IN_PROPERTIES.has(k));
-  if (misplaced.length) {
+  if (misplaced.length && options.persisted) {
+    warnings.push(
+      `Component "${label}": style keys ${JSON.stringify(misplaced)} are stored under \`properties\`, where ` +
+        `ToolJet ignores them. They are inert leftovers and cannot be removed by an update (ToolJet merges ` +
+        `component definitions and cannot delete keys) — do not attempt to repair this. Set styling on ` +
+        `\`styles\` instead; delete and recreate the component only if the user asks for it.`
+    );
+  } else if (misplaced.length) {
     errors.push(
       `Component "${label}": style keys ${JSON.stringify(misplaced)} are under \`properties\`, where ToolJet ` +
         `ignores them — move them to the top-level \`styles\` object.`
@@ -1904,7 +1920,7 @@ export function validateAppStructure(summary: AppSummary): LintResult {
       styles: c.styles,
       layouts: c.layouts as LintComponent['layouts'],
       parent: c.parent,
-    });
+    }, { persisted: true });
     errors.push(...r.errors);
     warnings.push(...r.warnings);
   }

--- a/src/tools/updateComponents.ts
+++ b/src/tools/updateComponents.ts
@@ -9,6 +9,7 @@ import {
   lintStandardSingleLineInputHeight,
   lintTextGeometry,
   lintUnusableTextGeometry,
+  STYLE_KEYS_IN_PROPERTIES,
   type LintComponent,
 } from '../lint.js';
 import { COMPONENT_SLOT_NAMES, decodeComponentParent, encodeComponentParent } from '../componentParent.js';
@@ -156,7 +157,25 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
           projected.set(current.id, normalizedNext);
           if (update.definition) changedComponents.push({ before: current as LintComponent, after: normalizedNext });
           placementChanged ||= update.parent !== undefined || update.slot_name !== undefined;
-          warnings.push(...normalized.warnings);
+          // The normalizer runs over current-merged-with-patch, so a style key already stored under
+          // `properties` makes it claim "moved style key X" for a key the caller never sent and that
+          // ToolJet's merge-only update cannot delete. Reading that as done loops the caller forever.
+          const storedMisplaced = Object.keys(current.properties ?? {}).filter((key) =>
+            STYLE_KEYS_IN_PROPERTIES.has(key)
+          );
+          warnings.push(
+            ...normalized.warnings.filter(
+              (warning) => !storedMisplaced.some((key) => warning.includes(`moved style key "${key}"`))
+            )
+          );
+          if (storedMisplaced.length) {
+            warnings.push(
+              `Component "${next.name}": style keys ${JSON.stringify(storedMisplaced)} were already stored under ` +
+                `\`properties\` before this update and REMAIN there — component updates merge and cannot delete ` +
+                `keys. Any new value you sent is applied to \`styles\` and renders correctly; the leftovers are ` +
+                `inert. Do not retry this update to clear them, it cannot work.`
+            );
+          }
           let normalizedDefinition = update.definition;
           if (update.definition && Object.keys(normalized.patch).length) {
             normalizedDefinition = { ...update.definition };

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -36,6 +36,16 @@ describe('lintComponentSpec', () => {
     expect(r.warnings).toEqual([]);
   });
 
+  it('WARNS instead of erroring for the same keys on an already-persisted component', () => {
+    const r = lintComponentSpec(
+      { name: 'title', type: 'Text', properties: { textColor: { value: '#111' } } },
+      { persisted: true }
+    );
+    expect(r.errors).toEqual([]);
+    expect(r.warnings.join(' ')).toMatch(/already.*|stored under `properties`/i);
+    expect(r.warnings.join(' ')).toMatch(/cannot be removed/i);
+  });
+
   it('warns when a Chart has no explicit (empty) title — the default clips', () => {
     const r = lintComponentSpec({ name: 'c', type: 'Chart', properties: { data: { value: [] } } });
     expect(r.warnings.join(' ')).toMatch(/native title defaults to a non-empty string that clips/);
@@ -1208,6 +1218,27 @@ describe('validateAppStructure', () => {
       events: [],
     };
     expect(validateAppStructure(corrupted).errors.join(' ')).toMatch(/malformed entries.*shredded dynamic binding/is);
+  });
+
+  it('does not FAIL an app over inherited style keys under properties (they are inert and unremovable)', () => {
+    const inherited: AppSummary = {
+      ...base,
+      pages: [{
+        id: 'p1',
+        name: 'Home',
+        components: [{
+          id: 'c9',
+          name: 'text1',
+          type: 'Text',
+          properties: { text: { value: 'hi' }, fontWeight: { value: 'bold' }, textColor: { value: '#111' } },
+        }],
+      }],
+      queries: [],
+      events: [],
+    };
+    const r = validateAppStructure(inherited);
+    expect(r.errors.join(' ')).not.toMatch(/style keys/);
+    expect(r.warnings.join(' ')).toMatch(/stored under `properties`/);
   });
 
   it('passes a well-formed app', () => {

--- a/tests/reliabilityTools.test.ts
+++ b/tests/reliabilityTools.test.ts
@@ -157,6 +157,32 @@ describe('update_components validation', () => {
     }));
   });
 
+  // Regression: "moved style key X" was reported for a stored key the caller never sent and that a
+  // merge-only update cannot delete, so the model read the impossible edit as done and retried it.
+  it('does not claim to have moved a style key it cannot remove from a persisted component', async () => {
+    const client = {
+      getAppSummary: vi.fn().mockResolvedValue({
+        app_id: 'app1',
+        pages: [{ id: 'p1', components: [{
+          id: 'c1', name: 'text1', type: 'Text',
+          properties: { text: { value: 'Hi' }, fontWeight: { value: 'bold' } }, styles: {},
+          layouts: { desktop: { top: 0, left: 0, width: 20, height: 40 } },
+        }] }],
+        queries: [], events: [],
+      }),
+      updateComponents: vi.fn().mockResolvedValue({ updated: 1 }),
+    } as unknown as ToolJetClient;
+    const result = await updateComponentsTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      updates: [{ component_id: 'text1', definition: { properties: { text: 'Bye' } } }],
+    });
+    expect(result.isError).not.toBe(true);
+    const warnings = (textOf(result) as { warnings: string[] }).warnings.join(' ');
+    expect(warnings).not.toMatch(/moved style key "fontWeight"/i);
+    expect(warnings).toMatch(/already stored under `properties`.*REMAIN there/i);
+    expect(warnings).toMatch(/cannot delete keys/i);
+  });
+
   it('lists what the page actually holds when nothing matches, instead of a bare "does not exist"', async () => {
     const client = {
       getAppSummary: vi.fn().mockResolvedValue({


### PR DESCRIPTION
This PR fixes builds being failed and repair-looped over pre-existing component defects, improving
how the persisted-app lint and update_components report findings no tool can act on.

**Persisted lint**

- Added `LintComponentSpecOptions { persisted?: boolean }` to `lintComponentSpec`; `validateAppStructure`
  now passes `{ persisted: true }` on its per-component re-lint.
- Style keys under `properties` stay a hard **error** on the write path, where moving them is free.
  On an already-stored component they become a **warning** — ToolJet reads styles from
  `definition.styles` and ignores these, and the normalizer writes new values into `styles`, so the
  component renders correctly. They are also unremovable: ToolJet merges component updates with
  lodash `mergeWith`, which has no delete path.
- Previously six inherited findings on one app made `validate_app` return `ok: false` forever, failing
  every subsequent build on that app regardless of what was requested.

**update_components**

- `normalizeComponentSpec` runs over current-merged-with-patch, so a style key already stored under
  `properties` made it report `moved style key "fontWeight" to styles.fontWeight` for a key the caller
  never sent and that the merge cannot delete.
- Those warnings are now filtered for keys present in the component's stored `properties`, replaced by
  one that says what actually happens: the new value lands in `styles`, the leftovers remain, updates
  cannot delete keys, do not retry.
- In the trace this fed a five-attempt loop (`""`, corrected ids, `null`, full bucket rewrite,
  `properties: {}`), each reporting `updated: 6` while `validate_app` kept flagging the same keys.

**Tests**

- `lint.test.ts` — warning on the persisted path, error on the write path, and `validateAppStructure`
  no longer failing an app over inherited style keys.
- `reliabilityTools.test.ts` — no false "moved style key", truthful warning present.

