### PR TITLE
Core reliability guards: strict update entries, binding identities, query aliases, partial-phase recovery

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33450,6 +33450,27 @@ function createAuth(config2, fetchImpl = fetch) {
 // dist/tooljetClient.js
 import { randomUUID } from "node:crypto";
 
+// dist/bindingReferences.js
+function bindingReferences(value) {
+  if (Array.isArray(value))
+    return value.flatMap(bindingReferences);
+  if (value && typeof value === "object")
+    return Object.values(value).flatMap(bindingReferences);
+  if (typeof value !== "string")
+    return [];
+  const refs2 = [];
+  for (const binding of value.matchAll(/\{\{([\s\S]*?)\}\}/g)) {
+    const tokens = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/\*[\s\S]*?\*\/|\/\/[^\n]*|(?<![\w$.])(components|queries)\s*(?:\?\.)?\s*(?:\.\s*([A-Za-z_$][\w$]*)|\[\s*(['"])([^'"\n]+)\3\s*\])|(?<![\w$.])(components|queries)\?\.\s*([A-Za-z_$][\w$]*)/g;
+    for (const match of binding[1].matchAll(tokens)) {
+      const namespace = match[1] || match[5];
+      const name = match[2] || match[4] || match[6];
+      if (namespace && name)
+        refs2.push({ namespace, name });
+    }
+  }
+  return refs2;
+}
+
 // dist/catalog.js
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -34861,6 +34882,22 @@ function validateAppStructure(summary) {
     const ev = e.event ?? {};
     if (ev.actionId === "run-query" && typeof ev.queryId === "string" && !queryIds.has(ev.queryId)) {
       errors.push(`Event "${name}" runs a query (${ev.queryId}) that no longer exists.`);
+    }
+  }
+  const bindingSources = [
+    ...allComponents.map((c) => ({ label: `Component "${c.name ?? c.id}"`, value: { p: c.properties, s: c.styles } })),
+    ...summary.queries.map((q) => ({ label: `Query "${q.name ?? q.id}"`, value: q.options })),
+    ...summary.events.map((e) => ({ label: `Event "${e.name ?? e.id}"`, value: e.event }))
+  ];
+  for (const source2 of bindingSources) {
+    const seen = /* @__PURE__ */ new Set();
+    for (const ref of bindingReferences(source2.value)) {
+      const names = ref.namespace === "components" ? componentNames : queryNames;
+      const key = `${ref.namespace}.${ref.name}`;
+      if (!names.has(ref.name) && !seen.has(key)) {
+        seen.add(key);
+        errors.push(`${source2.label} references ${key}, but no ${ref.namespace === "components" ? "component" : "query"} is named "${ref.name}". Binding names are case-sensitive; use the persisted name.`);
+      }
     }
   }
   for (const c of allComponents) {
@@ -38392,6 +38429,23 @@ function getAppSummaryTool(client) {
     },
     async handler(args) {
       try {
+        for (const key of [
+          "page_ids",
+          "page_names",
+          "page_handles",
+          "component_ids",
+          "component_names",
+          "component_types",
+          "query_ids",
+          "query_names",
+          "query_kinds",
+          "event_ids",
+          "event_source_ids"
+        ]) {
+          if (args[key]?.some((value) => !value.trim() || value === "*" || value === "00000000-0000-0000-0000-000000000000")) {
+            throw new Error(`${key} contains a placeholder, not an exact selector. Omit unused filters entirely; wildcards and dummy ids do not mean all resources. This is a filter error, not an empty app.`);
+          }
+        }
         const summary = await client.getAppSummary(args.app_id);
         return ok(selectAppSummary(summary, {
           sections: args.sections,
@@ -38762,6 +38816,23 @@ function validateEvents(summary, events, options2 = {}) {
   });
   for (const chain of chains.values()) {
     chain.sort((left, right) => left.index - right.index || Number(right.persisted) - Number(left.persisted));
+    chain.forEach(({ event }, index) => {
+      if (event.action.actionId !== "control-component" || !["selectOption", "selectOptions", "setText", "setValue"].includes(String(event.action.componentSpecificActionHandle)))
+        return;
+      let child = components.get(String(event.action.componentId));
+      const visited = /* @__PURE__ */ new Set();
+      while (child?.parent && !visited.has(child.id)) {
+        visited.add(child.id);
+        const parent = components.get(decodeComponentParent(child.parent).parentId);
+        if (!parent)
+          break;
+        if (parent.type === "ModalV2" && chain.slice(index + 1).some(({ event: later2 }) => later2.action.actionId === "show-modal" && later2.action.modal === parent.id)) {
+          errors.push(`Event "${event.name ?? index}": prefill targets a child of ModalV2 "${parent.name ?? parent.id}" before show-modal. Closed modal children are not mounted; these values can be lost. Bind input defaults to the selected record, or initialize after the modal opens.`);
+          break;
+        }
+        child = parent;
+      }
+    });
     const navigationIndex = chain.findIndex(({ event }) => event.action.actionId === "switch-page");
     if (navigationIndex === -1 || navigationIndex === chain.length - 1)
       continue;
@@ -40535,6 +40606,8 @@ function lintPlannedApp(spec, existingSummary) {
     if (existingQueryNames.has(query.name))
       errors.push(`App already has a query named "${query.name}".`);
     registerRef(queryRefs, ref, { id, name: query.name }, "query", errors);
+    if (ref !== query.name)
+      registerRef(queryRefs, query.name, { id, name: query.name }, "query", errors);
     queryIds.set(id, { id, name: query.name });
     let options2 = query.options;
     if (!query.kind) {
@@ -40777,7 +40850,12 @@ function sourceMap(sourceType, components, queries, pages) {
   return components;
 }
 function resolveAction(raw, queries, pages, components, errors, label) {
-  const { target_ref: targetRef, ...action } = raw;
+  const { target_ref: explicitRef, ...action } = raw;
+  const targetRef = explicitRef ?? (action.actionId === "run-query" ? action.queryId ?? action.queryName : void 0);
+  if (Object.values(action).some((value) => typeof value === "string" && /^planned-(query|page|component):/.test(value))) {
+    errors.push(`${label}: synthetic planned ids cannot be saved. Use action.target_ref with the logical client_ref or name.`);
+    return action;
+  }
   if (targetRef === void 0)
     return action;
   if (typeof targetRef !== "string") {
@@ -41171,7 +41249,8 @@ function sourceTarget(sourceType, ref, pages, queries, components) {
   return components.get(ref);
 }
 function resolveAction2(raw, pages, queries, components) {
-  const { target_ref: targetRef, ...action } = raw;
+  const { target_ref: explicitRef, ...action } = raw;
+  const targetRef = explicitRef ?? (action.actionId === "run-query" ? action.queryId ?? action.queryName : void 0);
   if (targetRef === void 0)
     return action;
   if (typeof targetRef !== "string")
@@ -41407,6 +41486,7 @@ function applyAppPhaseTool(client) {
           if (!created)
             throw new Error(`Could not resolve query "${query.name}" after creation.`);
           queryTargets.set(logicalRef(query), { id: created.query_id, name: created.name });
+          queryTargets.set(query.name, { id: created.query_id, name: created.name });
         });
         stage = "create page components";
         const preparedPages = (spec.pages ?? []).flatMap((page) => {
@@ -41516,7 +41596,22 @@ function applyAppPhaseTool(client) {
           validation
         });
       } catch (error51) {
-        return fail(new Error(`apply_app_phase failed during ${stage}. Applied before failure: ${appliedSummary(applied)}. The one-time plan token is consumed and no resources were auto-deleted. ${error51 instanceof Error ? error51.message : String(error51)}`));
+        let recovery = "";
+        if (Object.values(applied).some((count) => count > 0)) {
+          try {
+            const current = await client.getAppSummary(args.app_id);
+            recovery = " Persisted resources for targeted repair (do not recreate): " + JSON.stringify({
+              pages: current.pages.map((page) => ({
+                id: page.id,
+                name: page.name,
+                components: page.components.map((c) => ({ id: c.id, name: c.name }))
+              })),
+              queries: current.queries.map((q) => ({ id: q.id, name: q.name }))
+            }).slice(0, 12e3);
+          } catch {
+          }
+        }
+        return fail(new Error(`apply_app_phase failed during ${stage}. Applied before failure: ${appliedSummary(applied)}. The one-time plan token is consumed and no resources were auto-deleted. ${error51 instanceof Error ? error51.message : String(error51)}` + recovery));
       }
     }
   };

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -34953,6 +34953,18 @@ function validateAppStructure(summary) {
   return { errors: uniq(errors), warnings: uniq(warnings) };
 }
 
+// dist/strictEntry.js
+function strictEntry(shape, describeUnknown) {
+  return external_exports.strictObject(shape, {
+    error: (issue2) => issue2.code === "unrecognized_keys" ? issue2.keys.map(describeUnknown).join(" ") : void 0
+  });
+}
+function hasNonEmptyDefinition(definition) {
+  if (!definition)
+    return false;
+  return Object.values(definition).some((section) => section !== null && typeof section === "object" && Object.keys(section).length > 0);
+}
+
 // dist/tableValidation.js
 var TOOLJET_DB_RESERVED_COLUMN_NAMES = /* @__PURE__ */ new Set([
   "abort",
@@ -36207,8 +36219,11 @@ function createClient(auth, config2) {
   async function updateComponents(params) {
     const diff = {};
     for (const u of params.updates) {
-      const hasDef = !!u.definition && Object.keys(u.definition).length > 0;
+      const hasDef = hasNonEmptyDefinition(u.definition);
       const hasRaw = u.name !== void 0 || u.parent !== void 0 || u.slotName !== void 0;
+      if (!hasDef && !hasRaw) {
+        throw new Error(`updateComponents "${u.componentId}": nothing to update. Provide a non-empty definition (properties/styles/validation/others) or a name/parent change.`);
+      }
       if (hasDef && hasRaw) {
         throw new Error(`updateComponents "${u.componentId}": set EITHER definition (properties/styles/\u2026) OR name/parent/slotName in one entry \u2014 ToolJet applies only one path. Split into two update calls.`);
       }
@@ -36250,6 +36265,9 @@ function createClient(auth, config2) {
   async function updateLayouts(params) {
     const diff = {};
     for (const l of params.layouts) {
+      if (!l.desktop && !l.mobile && l.parent === void 0) {
+        throw new Error(`updateLayouts "${l.componentId}": nothing to update. Provide desktop and/or mobile rects, or a parent change.`);
+      }
       const entry = {
         layouts: {
           ...l.desktop ? { desktop: l.desktop } : {},
@@ -40150,8 +40168,21 @@ function normalizeComponentSpec(component, options2 = {}) {
     stylePatch[key] = stylesValue[key];
     normalizedSections.styles.value = stylesValue;
   };
+  const schema = getComponentSchema(component.type);
+  const knownPropertyKeys = schema ? new Set(schema.properties.map((entry) => entry.key)) : void 0;
+  const knownStyleKeys = schema ? new Set(schema.styles.map((entry) => entry.key)) : void 0;
+  const aliasTargetFor = (key) => {
+    if (knownPropertyKeys?.has(key))
+      return void 0;
+    const target = PROPERTY_KEY_ALIASES[key.toLowerCase()];
+    if (!target)
+      return void 0;
+    if (!schema)
+      return target;
+    return knownStyleKeys.has(target) || knownPropertyKeys.has(target) ? target : void 0;
+  };
   for (const key of Object.keys(properties)) {
-    const aliasTarget = PROPERTY_KEY_ALIASES[key.toLowerCase()];
+    const aliasTarget = aliasTargetFor(key);
     const canonical = aliasTarget ?? key;
     const belongsInStyles = canonical !== "styles" && STYLE_KEYS_IN_PROPERTIES.has(canonical);
     if (!aliasTarget && !belongsInStyles)
@@ -40253,8 +40284,8 @@ function normalizeComponentSpec(component, options2 = {}) {
     }
   }
   if (options2.stripUnknownKeys) {
-    const schema = getComponentSchema(component.type);
-    if (schema) {
+    const schema2 = getComponentSchema(component.type);
+    if (schema2) {
       const sections = [
         ["properties", properties],
         ["styles", normalizedSections.styles.value]
@@ -40262,7 +40293,7 @@ function normalizeComponentSpec(component, options2 = {}) {
       for (const [section, sectionValue] of sections) {
         if (!sectionValue)
           continue;
-        const knownKeys = (schema[section] ?? []).map((entry) => entry.key);
+        const knownKeys = (schema2[section] ?? []).map((entry) => entry.key);
         for (const key of Object.keys(sectionValue)) {
           if (!isStrippableUnknownKey(component.type, section, key, knownKeys))
             continue;
@@ -41583,12 +41614,12 @@ function addPagesTool(client) {
 }
 
 // dist/tools/updatePages.js
-var updateSchema = external_exports.object({
+var updateSchema = strictEntry({
   page_id: external_exports.string().min(1),
   name: external_exports.string().min(1).optional(),
   icon: external_exports.string().min(1).optional(),
   hidden: external_exports.boolean().optional().describe("Hide or show only this non-Home page in the generated navigation menu. This does not hide the whole menu; use update_app_settings.navigation_hidden for that.")
-});
+}, (key) => `Page update key "${key}" is not accepted; update_pages entries take page_id plus name, icon, hidden. App-level settings belong to update_app_settings.`);
 function updatePagesTool(client) {
   return {
     name: "update_pages",
@@ -41995,19 +42026,29 @@ function addComponentBatchesTool(client) {
 }
 
 // dist/tools/updateComponents.js
-var updateSchema2 = external_exports.object({
+var DEFINITION_SECTIONS = ["properties", "styles", "validation", "general", "general_styles", "others"];
+var definitionSchema = strictEntry({
+  properties: external_exports.record(external_exports.string(), external_exports.any()).optional(),
+  styles: external_exports.record(external_exports.string(), external_exports.any()).optional(),
+  validation: external_exports.record(external_exports.string(), external_exports.any()).optional(),
+  general: external_exports.record(external_exports.string(), external_exports.any()).optional(),
+  general_styles: external_exports.record(external_exports.string(), external_exports.any()).optional(),
+  others: external_exports.record(external_exports.string(), external_exports.any()).optional()
+}, (key) => key === "layout" || key === "layouts" ? `definition."${key}" is not a component definition section; move/resize with update_layout instead.` : `definition."${key}" is not a component definition section; use one of ${DEFINITION_SECTIONS.join("/")}.`);
+var updateSchema2 = strictEntry({
   component_id: external_exports.string(),
-  definition: external_exports.object({
-    properties: external_exports.record(external_exports.string(), external_exports.any()).optional(),
-    styles: external_exports.record(external_exports.string(), external_exports.any()).optional(),
-    validation: external_exports.record(external_exports.string(), external_exports.any()).optional(),
-    general: external_exports.record(external_exports.string(), external_exports.any()).optional(),
-    general_styles: external_exports.record(external_exports.string(), external_exports.any()).optional(),
-    others: external_exports.record(external_exports.string(), external_exports.any()).optional()
-  }).optional(),
+  definition: definitionSchema.optional(),
   name: external_exports.string().optional(),
   parent: external_exports.string().optional(),
   slot_name: external_exports.enum(COMPONENT_SLOT_NAMES).optional()
+}, (key) => {
+  if (DEFINITION_SECTIONS.includes(key)) {
+    return `Update entry key "${key}" must be nested under \`definition\` (e.g. { component_id, definition: { ${key}: {...} } }); top-level ${key} would write nothing.`;
+  }
+  if (key === "layout" || key === "layouts") {
+    return `Update entry key "${key}" is not accepted by update_components; move/resize with update_layout instead.`;
+  }
+  return `Unknown update entry key "${key}"; accepted keys are component_id, definition, name, parent, slot_name.`;
 });
 function updateComponentsTool(client) {
   return {
@@ -42018,7 +42059,7 @@ function updateComponentsTool(client) {
       destructiveHint: true,
       openWorldHint: true
     },
-    description: "Edit existing components IN PLACE instead of deleting + re-adding. Send only the CHANGED leaves under `definition` (properties/styles/validation/others) \u2014 ToolJet deep-merges, so untouched values are preserved. Leaves may be raw values or `{ value: ... }` envelopes; MCP canonicalizes them. NOTE: array values (Table `columns`, DropdownV2 `options`/`schema`) are REPLACED wholesale, so send the full array. Set EITHER `definition` OR name/parent/slot_name per entry, not both. `slot_name` accepts header/body/footer and can move a child between native ModalV2/Form/Container regions; omit parent to keep the current parent. Get component ids + current values from get_app_summary / get_component.",
+    description: "Edit existing components IN PLACE instead of deleting + re-adding. Send only the CHANGED leaves under `definition` (properties/styles/validation/others) \u2014 ToolJet deep-merges, so untouched values are preserved. Leaves may be raw values or `{ value: ... }` envelopes; MCP canonicalizes them. NOTE: array values (Table `columns`, DropdownV2 `options`/`schema`) are REPLACED wholesale, so send the full array. Set EITHER `definition` OR name/parent/slot_name per entry, not both. `slot_name` accepts header/body/footer and can move a child between native ModalV2/Form/Container regions; omit parent to keep the current parent. Unknown entry keys are rejected (a top-level properties/styles patch is an error, not a silent no-op), and an entry that changes nothing fails. Get component ids + current values from get_app_summary / get_component.",
     inputSchema: {
       app_id: external_exports.string(),
       version_id: external_exports.string(),
@@ -42049,6 +42090,10 @@ function updateComponentsTool(client) {
           const componentId = current.id;
           if (update.definition && (update.name !== void 0 || update.parent !== void 0 || update.slot_name !== void 0)) {
             errors.push(`Component "${update.component_id}": set EITHER definition OR name/parent/slot_name in one entry.`);
+            continue;
+          }
+          if (!hasNonEmptyDefinition(update.definition) && update.name === void 0 && update.parent === void 0 && update.slot_name === void 0) {
+            errors.push(`Component "${update.component_id}": nothing to update. Send the changed leaves under definition (properties/styles/validation/others) or a name/parent/slot_name change.`);
             continue;
           }
           let parent = update.parent;
@@ -42237,6 +42282,25 @@ function deleteComponentsTool(client) {
 
 // dist/tools/updateLayout.js
 var rect = external_exports.object({ top: external_exports.number(), left: external_exports.number(), width: external_exports.number(), height: external_exports.number() });
+var RECT_KEYS = /* @__PURE__ */ new Set(["top", "left", "width", "height"]);
+var layoutEntrySchema = strictEntry({
+  component_id: external_exports.string(),
+  desktop: rect.optional(),
+  mobile: rect.optional(),
+  parent: external_exports.string().optional(),
+  slot_name: external_exports.enum(COMPONENT_SLOT_NAMES).optional()
+}, (key) => {
+  if (RECT_KEYS.has(key)) {
+    return `Layout entry key "${key}" must be nested under desktop and/or mobile (e.g. { component_id, desktop: { top, left, width, height } }).`;
+  }
+  if (key === "layout" || key === "layouts") {
+    return `Layout entry key "${key}" is not accepted; put the rect directly under desktop and/or mobile on the entry.`;
+  }
+  if (key === "definition" || key === "properties" || key === "styles") {
+    return `Layout entry key "${key}" is not accepted by update_layout; edit component values with update_components.`;
+  }
+  return `Unknown layout entry key "${key}"; accepted keys are component_id, desktop, mobile, parent, slot_name.`;
+});
 function updateLayoutTool(client) {
   return {
     name: "update_layout",
@@ -42251,13 +42315,7 @@ function updateLayoutTool(client) {
       app_id: external_exports.string(),
       version_id: external_exports.string(),
       page_id: external_exports.string(),
-      layouts: external_exports.array(external_exports.object({
-        component_id: external_exports.string(),
-        desktop: rect.optional(),
-        mobile: rect.optional(),
-        parent: external_exports.string().optional(),
-        slot_name: external_exports.enum(COMPONENT_SLOT_NAMES).optional()
-      })).min(1)
+      layouts: external_exports.array(layoutEntrySchema).min(1)
     },
     async handler(args) {
       try {
@@ -42270,6 +42328,10 @@ function updateLayoutTool(client) {
         const resolveErrors = [];
         const resolvedIds = /* @__PURE__ */ new Map();
         for (const layout of args.layouts) {
+          if (!layout.desktop && !layout.mobile && layout.parent === void 0 && layout.slot_name === void 0) {
+            resolveErrors.push(`Component "${layout.component_id}": nothing to update. Provide desktop and/or mobile rects, or a parent/slot_name change.`);
+            continue;
+          }
           if (resolvedIds.has(layout.component_id))
             continue;
           const resolution = resolveRef2(page.components, layout.component_id, "Component", `on page "${args.page_id}"`);
@@ -43064,12 +43126,12 @@ function updateEventsTool(client) {
     inputSchema: {
       app_id: external_exports.string(),
       version_id: external_exports.string(),
-      events: external_exports.array(external_exports.object({
+      events: external_exports.array(strictEntry({
         event_id: external_exports.string(),
         name: external_exports.string().optional(),
         event: external_exports.record(external_exports.string(), external_exports.any()).optional(),
         index: external_exports.number().optional()
-      })).min(1),
+      }, (key) => `Event entry key "${key}" must be nested under \`event\` (the full { eventId, actionId, ...params } blob). Accepted entry keys are event_id, name, event, index.`)).min(1),
       update_type: external_exports.enum(["update", "reorder"]).optional()
     },
     async handler(args) {

--- a/src/appSpecLint.ts
+++ b/src/appSpecLint.ts
@@ -224,6 +224,7 @@ export function lintPlannedApp(spec: PlannedAppSpec, existingSummary?: AppSummar
     const id = `planned-query:${index}:${ref}`;
     if (existingQueryNames.has(query.name)) errors.push(`App already has a query named "${query.name}".`);
     registerRef(queryRefs, ref, { id, name: query.name }, 'query', errors);
+    if (ref !== query.name) registerRef(queryRefs, query.name, { id, name: query.name }, 'query', errors);
     queryIds.set(id, { id, name: query.name });
     // Repair a flat {column: value} tooljetdb write map before validating, so the phase this lint
     // hands to apply_app_phase persists the shape ToolJet actually reads. Without this, the plan
@@ -507,7 +508,12 @@ function resolveAction(
   errors: string[],
   label: string
 ): Record<string, unknown> {
-  const { target_ref: targetRef, ...action } = raw;
+  const { target_ref: explicitRef, ...action } = raw;
+  const targetRef = explicitRef ?? (action.actionId === 'run-query' ? action.queryId ?? action.queryName : undefined);
+  if (Object.values(action).some((value) => typeof value === 'string' && /^planned-(query|page|component):/.test(value))) {
+    errors.push(`${label}: synthetic planned ids cannot be saved. Use action.target_ref with the logical client_ref or name.`);
+    return action;
+  }
   if (targetRef === undefined) return action;
   if (typeof targetRef !== 'string') {
     errors.push(`${label} target_ref must be a string.`);

--- a/src/bindingReferences.ts
+++ b/src/bindingReferences.ts
@@ -1,0 +1,19 @@
+/** Read literal namespace references anywhere in a binding, not only immediately after {{.
+ * Not a JS evaluator. Quoted strings/comments are ignored; computed names are left unverified.
+ */
+export function bindingReferences(value: unknown): Array<{ namespace: 'components' | 'queries'; name: string }> {
+  if (Array.isArray(value)) return value.flatMap(bindingReferences);
+  if (value && typeof value === 'object') return Object.values(value).flatMap(bindingReferences);
+  if (typeof value !== 'string') return [];
+  const refs: Array<{ namespace: 'components' | 'queries'; name: string }> = [];
+  for (const binding of value.matchAll(/\{\{([\s\S]*?)\}\}/g)) {
+    // Consume quoted strings first so examples such as 'components.foo' are not dependencies.
+    const tokens = /'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/\*[\s\S]*?\*\/|\/\/[^\n]*|(?<![\w$.])(components|queries)\s*(?:\?\.)?\s*(?:\.\s*([A-Za-z_$][\w$]*)|\[\s*(['"])([^'"\n]+)\3\s*\])|(?<![\w$.])(components|queries)\?\.\s*([A-Za-z_$][\w$]*)/g;
+    for (const match of binding[1].matchAll(tokens)) {
+      const namespace = match[1] || match[5];
+      const name = match[2] || match[4] || match[6];
+      if (namespace && name) refs.push({ namespace: namespace as 'components' | 'queries', name });
+    }
+  }
+  return refs;
+}

--- a/src/componentNormalization.ts
+++ b/src/componentNormalization.ts
@@ -121,8 +121,23 @@ export function normalizeComponentSpec<T extends ComponentSpec>(
     stylePatch[key] = stylesValue[key];
     normalizedSections.styles.value = stylesValue;
   };
+  // Aliases are scoped to the component's real schema: a key that IS a property of this type is never
+  // an alias (ModalV2 `size` = modal width sm/md/lg/xl, not textSize), and an alias only fires when its
+  // target exists on this type (Divider has no textColor for `color` to become). Otherwise the rewrite
+  // itself creates the unknown key the linter then warns about. Types missing from the catalog keep the
+  // unscoped behaviour.
+  const schema = getComponentSchema(component.type);
+  const knownPropertyKeys = schema ? new Set(schema.properties.map((entry) => entry.key)) : undefined;
+  const knownStyleKeys = schema ? new Set(schema.styles.map((entry) => entry.key)) : undefined;
+  const aliasTargetFor = (key: string): string | undefined => {
+    if (knownPropertyKeys?.has(key)) return undefined;
+    const target = PROPERTY_KEY_ALIASES[key.toLowerCase()];
+    if (!target) return undefined;
+    if (!schema) return target;
+    return knownStyleKeys!.has(target) || knownPropertyKeys!.has(target) ? target : undefined;
+  };
   for (const key of Object.keys(properties)) {
-    const aliasTarget = PROPERTY_KEY_ALIASES[key.toLowerCase()];
+    const aliasTarget = aliasTargetFor(key);
     const canonical = aliasTarget ?? key;
     const belongsInStyles = canonical !== 'styles' && STYLE_KEYS_IN_PROPERTIES.has(canonical);
     if (!aliasTarget && !belongsInStyles) continue;

--- a/src/eventValidation.ts
+++ b/src/eventValidation.ts
@@ -1,5 +1,6 @@
 import { getComponentSchema } from './catalog.js';
 import { resolveRef } from './refResolution.js';
+import { decodeComponentParent } from './componentParent.js';
 import type { AppSummary, EventSpec, EventSourceType } from './tooljetClient.js';
 
 export interface EventValidationResult {
@@ -355,6 +356,27 @@ export function validateEvents(
   });
   for (const chain of chains.values()) {
     chain.sort((left, right) => left.index - right.index || Number(right.persisted) - Number(left.persisted));
+    // A closed ModalV2 unmounts its children. Imperative prefill before show-modal is lost
+    // when those controls mount with their defaults (observed in the Luna UI benchmark).
+    chain.forEach(({ event }, index) => {
+      if (event.action.actionId !== 'control-component' ||
+          !['selectOption', 'selectOptions', 'setText', 'setValue'].includes(String(event.action.componentSpecificActionHandle))) return;
+      let child = components.get(String(event.action.componentId));
+      const visited = new Set<string>();
+      while (child?.parent && !visited.has(child.id)) {
+        visited.add(child.id);
+        const parent = components.get(decodeComponentParent(child.parent).parentId);
+        if (!parent) break;
+        if (parent.type === 'ModalV2' && chain.slice(index + 1).some(({ event: later }) =>
+          later.action.actionId === 'show-modal' && later.action.modal === parent.id)) {
+          errors.push(`Event "${event.name ?? index}": prefill targets a child of ModalV2 "${parent.name ?? parent.id}" ` +
+            'before show-modal. Closed modal children are not mounted; these values can be lost. ' +
+            'Bind input defaults to the selected record, or initialize after the modal opens.');
+          break;
+        }
+        child = parent;
+      }
+    });
     const navigationIndex = chain.findIndex(({ event }) => event.action.actionId === 'switch-page');
     if (navigationIndex === -1 || navigationIndex === chain.length - 1) continue;
     const navigation = chain[navigationIndex]!;

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -2,6 +2,7 @@
 // against. Used by add_component(s) (component-level, pre-write) and validate_app (whole-app,
 // post-write). Errors block; warnings are surfaced to the agent but don't block.
 import type { AppSummary } from './tooljetClient.js';
+import { bindingReferences } from './bindingReferences.js';
 import { getCatalog, getComponentSchema, getLegacyComponentReplacement } from './catalog.js';
 import { COMPONENT_SLOT_NAMES, decodeComponentParent, type ComponentSlotName } from './componentParent.js';
 import {
@@ -1884,6 +1885,23 @@ export function validateAppStructure(summary: AppSummary): LintResult {
   }
 
   // Bindings to non-existent queries/components + re-run per-component render lints.
+  const bindingSources = [
+    ...allComponents.map((c) => ({ label: `Component "${c.name ?? c.id}"`, value: { p: c.properties, s: c.styles } })),
+    ...summary.queries.map((q) => ({ label: `Query "${q.name ?? q.id}"`, value: q.options })),
+    ...summary.events.map((e) => ({ label: `Event "${e.name ?? e.id}"`, value: e.event })),
+  ];
+  for (const source of bindingSources) {
+    const seen = new Set<string>();
+    for (const ref of bindingReferences(source.value)) {
+      const names = ref.namespace === 'components' ? componentNames : queryNames;
+      const key = `${ref.namespace}.${ref.name}`;
+      if (!names.has(ref.name) && !seen.has(key)) {
+        seen.add(key);
+        errors.push(`${source.label} references ${key}, but no ${ref.namespace === 'components' ? 'component' : 'query'} ` +
+          `is named "${ref.name}". Binding names are case-sensitive; use the persisted name.`);
+      }
+    }
+  }
   for (const c of allComponents) {
     const blob = JSON.stringify({ p: c.properties ?? {}, s: c.styles ?? {} });
     for (const m of blob.matchAll(/\{\{\s*queries\.([A-Za-z0-9_]+)/g)) {

--- a/src/strictEntry.ts
+++ b/src/strictEntry.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * A batch-entry schema that REJECTS unknown keys with an actionable message.
+ *
+ * Plain z.object() silently strips keys it does not know. For an update entry that is the worst
+ * possible behaviour: `{ component_id, properties: {...} }` (patch at the top level instead of under
+ * `definition`) parses to `{ component_id }`, the write becomes an empty diff, ToolJet answers 200,
+ * and the tool reports "updated". Observed live on 2026-09-05: five such calls in a row, nothing
+ * persisted, no signal. Rejecting the key names the fix in the same turn instead.
+ *
+ * `describeUnknown` turns the offending key into the message the model reads.
+ */
+export function strictEntry<T extends z.ZodRawShape>(
+  shape: T,
+  describeUnknown: (key: string) => string
+) {
+  return z.strictObject(shape, {
+    error: (issue) =>
+      issue.code === 'unrecognized_keys'
+        ? (issue.keys as string[]).map(describeUnknown).join(' ')
+        : undefined,
+  });
+}
+
+/** True when `definition` carries at least one section with at least one leaf to write. */
+export function hasNonEmptyDefinition(definition: Record<string, unknown> | undefined): boolean {
+  if (!definition) return false;
+  return Object.values(definition).some(
+    (section) => section !== null && typeof section === 'object' && Object.keys(section as object).length > 0
+  );
+}

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { Auth, Workspace } from './auth.js';
 import type { Config } from './config.js';
 import { STYLE_KEYS_IN_PROPERTIES } from './lint.js';
+import { hasNonEmptyDefinition } from './strictEntry.js';
 import { decodeComponentParent, encodeComponentParent, type ComponentSlotName } from './componentParent.js';
 import { tableCreationLevels, TOOLJET_DB_RESERVED_COLUMN_NAMES } from './tableValidation.js';
 import { booleanBindingValue, isCanonicalStaticBooleanBinding, staticBooleanBinding } from './bindings.js';
@@ -1835,8 +1836,16 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   async function updateComponents(params: UpdateComponentsParams): Promise<{ updated: number }> {
     const diff: Record<string, unknown> = {};
     for (const u of params.updates) {
-      const hasDef = !!u.definition && Object.keys(u.definition).length > 0;
+      const hasDef = hasNonEmptyDefinition(u.definition);
       const hasRaw = u.name !== undefined || u.parent !== undefined || u.slotName !== undefined;
+      if (!hasDef && !hasRaw) {
+        // Never PUT an empty diff: ToolJet answers 200 without writing and the caller would report
+        // it as updated. Observed live when a patch was sent outside `definition` and stripped.
+        throw new Error(
+          `updateComponents "${u.componentId}": nothing to update. Provide a non-empty definition ` +
+            '(properties/styles/validation/others) or a name/parent change.'
+        );
+      }
       if (hasDef && hasRaw) {
         throw new Error(
           `updateComponents "${u.componentId}": set EITHER definition (properties/styles/…) OR name/parent/slotName ` +
@@ -1891,6 +1900,11 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
   async function updateLayouts(params: UpdateLayoutsParams): Promise<{ updated: number }> {
     const diff: Record<string, unknown> = {};
     for (const l of params.layouts) {
+      if (!l.desktop && !l.mobile && l.parent === undefined) {
+        throw new Error(
+          `updateLayouts "${l.componentId}": nothing to update. Provide desktop and/or mobile rects, or a parent change.`
+        );
+      }
       const entry: Record<string, unknown> = {
         layouts: {
           ...(l.desktop ? { desktop: l.desktop } : {}),

--- a/src/tools/applyAppPhase.ts
+++ b/src/tools/applyAppPhase.ts
@@ -38,7 +38,8 @@ function resolveAction(
   queries: Map<string, LogicalTarget>,
   components: Map<string, LogicalTarget>
 ): Record<string, unknown> {
-  const { target_ref: targetRef, ...action } = raw;
+  const { target_ref: explicitRef, ...action } = raw;
+  const targetRef = explicitRef ?? (action.actionId === 'run-query' ? action.queryId ?? action.queryName : undefined);
   if (targetRef === undefined) return action;
   if (typeof targetRef !== 'string') throw new Error('Event action target_ref must be a string.');
   const actionId = String(action.actionId);
@@ -327,6 +328,7 @@ export function applyAppPhaseTool(client: ToolJetClient): ToolDef {
           const created = createdQueries[index];
           if (!created) throw new Error(`Could not resolve query "${query.name}" after creation.`);
           queryTargets.set(logicalRef(query), { id: created.query_id, name: created.name });
+          queryTargets.set(query.name, { id: created.query_id, name: created.name });
         });
 
         stage = 'create page components';
@@ -446,10 +448,21 @@ export function applyAppPhaseTool(client: ToolJetClient): ToolDef {
           validation,
         });
       } catch (error) {
+        let recovery = '';
+        if (Object.values(applied).some((count) => count > 0)) {
+          try {
+            const current = await client.getAppSummary(args.app_id);
+            recovery = ' Persisted resources for targeted repair (do not recreate): ' + JSON.stringify({
+              pages: current.pages.map((page) => ({ id: page.id, name: page.name,
+                components: page.components.map((c) => ({ id: c.id, name: c.name })) })),
+              queries: current.queries.map((q) => ({ id: q.id, name: q.name })),
+            }).slice(0, 12000);
+          } catch { /* Preserve the original failure if even the recovery read is unavailable. */ }
+        }
         return fail(new Error(
           `apply_app_phase failed during ${stage}. Applied before failure: ${appliedSummary(applied)}. ` +
             `The one-time plan token is consumed and no resources were auto-deleted. ` +
-            `${error instanceof Error ? error.message : String(error)}`
+            `${error instanceof Error ? error.message : String(error)}` + recovery
         ));
       }
     },

--- a/src/tools/getAppSummary.ts
+++ b/src/tools/getAppSummary.ts
@@ -71,6 +71,13 @@ export function getAppSummaryTool(client: ToolJetClient): ToolDef {
     },
     async handler(args: GetAppSummaryArgs) {
       try {
+        for (const key of ['page_ids', 'page_names', 'page_handles', 'component_ids', 'component_names',
+          'component_types', 'query_ids', 'query_names', 'query_kinds', 'event_ids', 'event_source_ids'] as const) {
+          if (args[key]?.some((value) => !value.trim() || value === '*' || value === '00000000-0000-0000-0000-000000000000')) {
+            throw new Error(`${key} contains a placeholder, not an exact selector. Omit unused filters entirely; ` +
+              'wildcards and dummy ids do not mean all resources. This is a filter error, not an empty app.');
+          }
+        }
         const summary = await client.getAppSummary(args.app_id);
         return ok(
           selectAppSummary(summary, {

--- a/src/tools/updateComponents.ts
+++ b/src/tools/updateComponents.ts
@@ -15,23 +15,45 @@ import { COMPONENT_SLOT_NAMES, decodeComponentParent, encodeComponentParent } fr
 import { ok, fail, type ToolDef } from './types.js';
 import { normalizeComponentSpec } from '../componentNormalization.js';
 import { resolveRef } from '../refResolution.js';
+import { hasNonEmptyDefinition, strictEntry } from '../strictEntry.js';
 
-const updateSchema = z.object({
-  component_id: z.string(),
-  definition: z
-    .object({
-      properties: z.record(z.string(), z.any()).optional(),
-      styles: z.record(z.string(), z.any()).optional(),
-      validation: z.record(z.string(), z.any()).optional(),
-      general: z.record(z.string(), z.any()).optional(),
-      general_styles: z.record(z.string(), z.any()).optional(),
-      others: z.record(z.string(), z.any()).optional(),
-    })
-    .optional(),
-  name: z.string().optional(),
-  parent: z.string().optional(),
-  slot_name: z.enum(COMPONENT_SLOT_NAMES).optional(),
-});
+const DEFINITION_SECTIONS = ['properties', 'styles', 'validation', 'general', 'general_styles', 'others'] as const;
+
+const definitionSchema = strictEntry(
+  {
+    properties: z.record(z.string(), z.any()).optional(),
+    styles: z.record(z.string(), z.any()).optional(),
+    validation: z.record(z.string(), z.any()).optional(),
+    general: z.record(z.string(), z.any()).optional(),
+    general_styles: z.record(z.string(), z.any()).optional(),
+    others: z.record(z.string(), z.any()).optional(),
+  },
+  (key) =>
+    key === 'layout' || key === 'layouts'
+      ? `definition."${key}" is not a component definition section; move/resize with update_layout instead.`
+      : `definition."${key}" is not a component definition section; use one of ${DEFINITION_SECTIONS.join('/')}.`
+);
+
+// Unknown entry keys are rejected, never stripped: a stripped `properties` produced an empty diff
+// that ToolJet accepted with 200 and the tool reported as updated (see src/strictEntry.ts).
+const updateSchema = strictEntry(
+  {
+    component_id: z.string(),
+    definition: definitionSchema.optional(),
+    name: z.string().optional(),
+    parent: z.string().optional(),
+    slot_name: z.enum(COMPONENT_SLOT_NAMES).optional(),
+  },
+  (key) => {
+    if ((DEFINITION_SECTIONS as readonly string[]).includes(key)) {
+      return `Update entry key "${key}" must be nested under \`definition\` (e.g. { component_id, definition: { ${key}: {...} } }); top-level ${key} would write nothing.`;
+    }
+    if (key === 'layout' || key === 'layouts') {
+      return `Update entry key "${key}" is not accepted by update_components; move/resize with update_layout instead.`;
+    }
+    return `Unknown update entry key "${key}"; accepted keys are component_id, definition, name, parent, slot_name.`;
+  }
+);
 
 export function updateComponentsTool(client: ToolJetClient): ToolDef {
   return {
@@ -49,7 +71,9 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
       'NOTE: array values (Table `columns`, DropdownV2 `options`/`schema`) are ' +
       'REPLACED wholesale, so send the full array. Set EITHER `definition` OR name/parent/slot_name per entry, ' +
       'not both. `slot_name` accepts header/body/footer and can move a child between native ModalV2/Form/Container ' +
-      'regions; omit parent to keep the current parent. Get component ids + current values from get_app_summary / get_component.',
+      'regions; omit parent to keep the current parent. Unknown entry keys are rejected (a top-level properties/styles ' +
+      'patch is an error, not a silent no-op), and an entry that changes nothing fails. Get component ids + current ' +
+      'values from get_app_summary / get_component.',
     inputSchema: {
       app_id: z.string(),
       version_id: z.string(),
@@ -102,6 +126,19 @@ export function updateComponentsTool(client: ToolJetClient): ToolDef {
           if (update.definition && (update.name !== undefined || update.parent !== undefined || update.slot_name !== undefined)) {
             errors.push(
               `Component "${update.component_id}": set EITHER definition OR name/parent/slot_name in one entry.`
+            );
+            continue;
+          }
+          // An entry with nothing to write must fail here. Letting it through produced an empty diff
+          // that ToolJet accepted with 200 and this tool reported as `updated`, so a model kept
+          // believing edits had landed when nothing was persisted.
+          if (
+            !hasNonEmptyDefinition(update.definition) &&
+            update.name === undefined && update.parent === undefined && update.slot_name === undefined
+          ) {
+            errors.push(
+              `Component "${update.component_id}": nothing to update. Send the changed leaves under definition ` +
+                '(properties/styles/validation/others) or a name/parent/slot_name change.'
             );
             continue;
           }

--- a/src/tools/updateEvents.ts
+++ b/src/tools/updateEvents.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { ToolJetClient } from '../tooljetClient.js';
 import { persistedEventSpecs, validateEvents } from '../eventValidation.js';
 import { ok, fail, type ToolDef } from './types.js';
+import { strictEntry } from '../strictEntry.js';
 
 export function updateEventsTool(client: ToolJetClient): ToolDef {
   return {
@@ -22,12 +23,17 @@ export function updateEventsTool(client: ToolJetClient): ToolDef {
       version_id: z.string(),
       events: z
         .array(
-          z.object({
-            event_id: z.string(),
-            name: z.string().optional(),
-            event: z.record(z.string(), z.any()).optional(),
-            index: z.number().optional(),
-          })
+          strictEntry(
+            {
+              event_id: z.string(),
+              name: z.string().optional(),
+              event: z.record(z.string(), z.any()).optional(),
+              index: z.number().optional(),
+            },
+            (key) =>
+              `Event entry key "${key}" must be nested under \`event\` (the full { eventId, actionId, ...params } blob). ` +
+              'Accepted entry keys are event_id, name, event, index.'
+          )
         )
         .min(1),
       update_type: z.enum(['update', 'reorder']).optional(),

--- a/src/tools/updateLayout.ts
+++ b/src/tools/updateLayout.ts
@@ -13,8 +13,35 @@ import {
 import { COMPONENT_SLOT_NAMES, decodeComponentParent, encodeComponentParent } from '../componentParent.js';
 import { ok, fail, type ToolDef } from './types.js';
 import { resolveRef } from '../refResolution.js';
+import { strictEntry } from '../strictEntry.js';
 
 const rect = z.object({ top: z.number(), left: z.number(), width: z.number(), height: z.number() });
+
+const RECT_KEYS = new Set(['top', 'left', 'width', 'height']);
+
+// Unknown entry keys are rejected, never stripped: a stripped rect or wrapper left an entry with
+// nothing to write, which went out as an empty diff and was reported as updated (see src/strictEntry.ts).
+const layoutEntrySchema = strictEntry(
+  {
+    component_id: z.string(),
+    desktop: rect.optional(),
+    mobile: rect.optional(),
+    parent: z.string().optional(),
+    slot_name: z.enum(COMPONENT_SLOT_NAMES).optional(),
+  },
+  (key) => {
+    if (RECT_KEYS.has(key)) {
+      return `Layout entry key "${key}" must be nested under desktop and/or mobile (e.g. { component_id, desktop: { top, left, width, height } }).`;
+    }
+    if (key === 'layout' || key === 'layouts') {
+      return `Layout entry key "${key}" is not accepted; put the rect directly under desktop and/or mobile on the entry.`;
+    }
+    if (key === 'definition' || key === 'properties' || key === 'styles') {
+      return `Layout entry key "${key}" is not accepted by update_layout; edit component values with update_components.`;
+    }
+    return `Unknown layout entry key "${key}"; accepted keys are component_id, desktop, mobile, parent, slot_name.`;
+  }
+);
 
 export function updateLayoutTool(client: ToolJetClient): ToolDef {
   return {
@@ -34,17 +61,7 @@ export function updateLayoutTool(client: ToolJetClient): ToolDef {
       app_id: z.string(),
       version_id: z.string(),
       page_id: z.string(),
-      layouts: z
-        .array(
-          z.object({
-            component_id: z.string(),
-            desktop: rect.optional(),
-            mobile: rect.optional(),
-            parent: z.string().optional(),
-            slot_name: z.enum(COMPONENT_SLOT_NAMES).optional(),
-          })
-        )
-        .min(1),
+      layouts: z.array(layoutEntrySchema).min(1),
     },
     async handler(args: {
       app_id: string;
@@ -70,6 +87,12 @@ export function updateLayoutTool(client: ToolJetClient): ToolDef {
         const resolveErrors: string[] = [];
         const resolvedIds = new Map<string, string>();
         for (const layout of args.layouts) {
+          if (!layout.desktop && !layout.mobile && layout.parent === undefined && layout.slot_name === undefined) {
+            resolveErrors.push(
+              `Component "${layout.component_id}": nothing to update. Provide desktop and/or mobile rects, or a parent/slot_name change.`
+            );
+            continue;
+          }
           if (resolvedIds.has(layout.component_id)) continue;
           const resolution = resolveRef(page.components, layout.component_id, 'Component', `on page "${args.page_id}"`);
           if (!resolution.ok) {

--- a/src/tools/updatePages.ts
+++ b/src/tools/updatePages.ts
@@ -1,16 +1,24 @@
 import { z } from 'zod';
 import type { ToolJetClient } from '../tooljetClient.js';
 import { fail, ok, type ToolDef } from './types.js';
+import { strictEntry } from '../strictEntry.js';
 
-const updateSchema = z.object({
-  page_id: z.string().min(1),
-  name: z.string().min(1).optional(),
-  icon: z.string().min(1).optional(),
-  hidden: z.boolean().optional().describe(
-    'Hide or show only this non-Home page in the generated navigation menu. ' +
-    'This does not hide the whole menu; use update_app_settings.navigation_hidden for that.'
-  ),
-});
+// Unknown entry keys are rejected, never stripped, so a misspelt field is an error rather than a
+// page update that quietly changes nothing (see src/strictEntry.ts).
+const updateSchema = strictEntry(
+  {
+    page_id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    icon: z.string().min(1).optional(),
+    hidden: z.boolean().optional().describe(
+      'Hide or show only this non-Home page in the generated navigation menu. ' +
+      'This does not hide the whole menu; use update_app_settings.navigation_hidden for that.'
+    ),
+  },
+  (key) =>
+    `Page update key "${key}" is not accepted; update_pages entries take page_id plus name, icon, hidden. ` +
+    'App-level settings belong to update_app_settings.'
+);
 
 export function updatePagesTool(client: ToolJetClient): ToolDef {
   return {

--- a/tests/appPhaseTools.test.ts
+++ b/tests/appPhaseTools.test.ts
@@ -12,7 +12,12 @@ function textOf(result: { content: Array<{ text: string }> }): any {
 describe('plan token + apply_app_phase', () => {
   beforeEach(() => clearAppPlansForTests());
 
-  it('applies the exact validated phase, resolves refs, combines events, and consumes the token', async () => {
+  it.each([
+    { actionId: 'run-query', target_ref: 'create' },
+    { actionId: 'run-query', queryId: 'create' },
+    { actionId: 'run-query', queryId: 'create_case' },
+    { actionId: 'run-query', queryName: 'create_case' },
+  ])('applies the exact validated phase with query reference %j and consumes the token', async (action) => {
     let persistedEvents: EventSpec[] = [];
     let summaryReads = 0;
     let tableCreated = false;
@@ -106,7 +111,7 @@ describe('plan token + apply_app_phase', () => {
           { client_ref: 'save', name: 'saveCase', type: 'Button', properties: { text: 'Save' }, layout: { top: 120, left: 2, width: 6, height: 40 } },
         ],
       }],
-      events: [{ source_ref: 'save', source_type: 'component', trigger: 'onClick', action: { actionId: 'run-query', target_ref: 'create' } }],
+      events: [{ source_ref: 'save', source_type: 'component', trigger: 'onClick', action }],
       lifecycles: [{ query_ref: 'create', refresh_query_refs: ['list'], clear_component_refs: ['title'], success_alert: { message: 'Created' }, failure_alert: { message: 'Failed' } }],
     });
     const planToken = textOf(lintResult).plan_token;
@@ -131,6 +136,7 @@ describe('plan token + apply_app_phase', () => {
       queries: expect.arrayContaining([expect.objectContaining({ options: expect.objectContaining({ table_id: 'table-id' }) })]),
     }));
     expect(client.createEvents).toHaveBeenCalledOnce();
+    expect(persistedEvents[0].action).toMatchObject({ queryId: 'create-id', queryName: 'create_case' });
 
     const retry = await applyAppPhaseTool(client).handler({ app_id: 'app1', version_id: 'v1', plan_token: planToken });
     expect(retry.isError).toBe(true);
@@ -189,6 +195,7 @@ describe('plan token + apply_app_phase', () => {
     expect(result.content[0]!.text).toMatch(/Applied before failure:.*pages=1/i);
     expect(result.content[0]!.text).toMatch(/no resources were auto-deleted/i);
     expect(result.content[0]!.text).toMatch(/Persisted before failure.*page-a/i);
+    expect(result.content[0]!.text).toContain('Persisted resources for targeted repair');
   });
 
   it('applies a repair phase that targets an existing query without recreating it', async () => {

--- a/tests/lunaRegression.test.ts
+++ b/tests/lunaRegression.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bindingReferences } from '../src/bindingReferences.js';
+import { validateAppStructure } from '../src/lint.js';
+import { getAppSummaryTool } from '../src/tools/getAppSummary.js';
+import { lintPlannedApp } from '../src/appSpecLint.js';
+import { validateEvents } from '../src/eventValidation.js';
+import type { EventSpec } from '../src/tooljetClient.js';
+import type { AppSummary, ToolJetClient } from '../src/tooljetClient.js';
+
+describe('Luna trace regressions (shared contracts)', () => {
+  it('rejects prefill before a modal mounts, but allows mounted input controls and declarative defaults', () => {
+    const summary: AppSummary = {app_id:'a',pages:[{id:'p',name:'Home',components:[
+      {id:'queue',name:'Queue',type:'Table'},
+      {id:'modal',name:'EditJob',type:'ModalV2'},
+      {id:'notes',name:'Notes',type:'TextArea',parent:'modal'},
+      {id:'outside',name:'Outside',type:'TextArea'},
+    ]}],queries:[],events:[]};
+    const prefill: EventSpec = {sourceId:'queue',sourceType:'component',trigger:'onRowClicked',
+      action:{actionId:'control-component',componentId:'notes',componentSpecificActionHandle:'setText',
+        componentSpecificActionParams:[{handle:'text',value:'{{components.Queue.selectedRow.notes}}'}]}};
+    const open: EventSpec = {sourceId:'queue',sourceType:'component',trigger:'onRowClicked',
+      action:{actionId:'show-modal',modal:'modal'}};
+    expect(validateEvents(summary,[prefill,open]).errors.join(' ')).toContain('before show-modal');
+    expect(validateEvents(summary,[open]).errors).toEqual([]);
+    expect(validateEvents(summary,[{...prefill,action:{...prefill.action,componentId:'outside'}},open]).errors).toEqual([]);
+    expect(validateEvents(summary,[{...prefill,sourceId:'modal',trigger:'onOpen'}]).errors).toEqual([]);
+  });
+  it('rejects copying synthetic ids from diagnostics into event actions', () => {
+    const result = lintPlannedApp({
+      queries: [{clientRef:'jobs',name:'jobs',kind:'runjs',options:{code:'return []'}}],
+      pages: [{name:'Home',icon:'IconHome2',components:[{name:'Refresh',type:'Button'}]}],
+      events: [{sourceRef:'Refresh',sourceType:'component',trigger:'onClick',
+        action:{actionId:'run-query',queryId:'planned-query:0:jobs'}}],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(' ')).toContain('synthetic planned ids cannot be saved');
+  });
+  it('finds embedded and optional references, not quoted examples or plain text', () => {
+    expect(bindingReferences({value: "{{(queries.jobs.data||[]).filter(r => !components.SearchJobs?.value && components?.Status.value && components['Owner'].value)}}"}))
+      .toEqual([{namespace:'queries',name:'jobs'}, {namespace:'components',name:'SearchJobs'},
+        {namespace:'components',name:'Status'}, {namespace:'components',name:'Owner'}]);
+    expect(bindingReferences("{{'components.fake' + \"queries.fake\" /* components.fake */}}" )).toEqual([]);
+    expect(bindingReferences('Documentation: components.fake')).toEqual([]);
+  });
+
+  it('catches case mistakes inside filters and save query inputs', () => {
+    const summary: AppSummary = { app_id:'a', name:'A', pages:[{id:'p',name:'Home',handle:'home',components:[
+      {id:'search',name:'SearchJobs',type:'TextInput'},
+      {id:'list',name:'Queue',type:'Table',properties:{data:{value:'{{(queries.jobs.data||[]).filter(r=>!components.searchJobs?.value)}}'}}},
+    ]}],queries:[{id:'q',name:'jobs'}, {id:'save',name:'save',options:{value:'{{components.editTechnician.value}}'}}],events:[] };
+    const result = validateAppStructure(summary);
+    expect(result.errors.join(' ')).toContain('components.searchJobs');
+    expect(result.errors.join(' ')).toContain('components.editTechnician');
+  });
+
+  it('rejects placeholder selectors instead of returning a misleading empty app', async () => {
+    const getAppSummary = vi.fn().mockResolvedValue({app_id:'a',pages:[],queries:[],events:[]});
+    const tool = getAppSummaryTool({getAppSummary} as unknown as ToolJetClient);
+    for (const placeholder of ['', '*', '00000000-0000-0000-0000-000000000000']) {
+      const result = await tool.handler({app_id:'a',page_ids:[placeholder]});
+      expect(result.isError).toBe(true);
+    }
+    expect(getAppSummary).not.toHaveBeenCalled();
+    expect((await tool.handler({app_id:'a'})).isError).not.toBe(true);
+  });
+});

--- a/tests/strictUpdateSchemas.test.ts
+++ b/tests/strictUpdateSchemas.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { ToolJetClient } from '../src/tooljetClient.js';
+import { createClient } from '../src/tooljetClient.js';
+import type { Config } from '../src/config.js';
+import type { Auth } from '../src/auth.js';
+import { updateComponentsTool } from '../src/tools/updateComponents.js';
+import { updateLayoutTool } from '../src/tools/updateLayout.js';
+import { updateEventsTool } from '../src/tools/updateEvents.js';
+import { updatePagesTool } from '../src/tools/updatePages.js';
+import type { ToolDef } from '../src/tools/types.js';
+import { normalizeComponentSpec } from '../src/componentNormalization.js';
+
+// The MCP SDK wraps every tool's raw shape in z.object() before the handler runs; mirror that here so
+// the tests exercise exactly the validation the model's payload meets.
+function parseArgs(tool: ToolDef, args: unknown) {
+  return z.object(tool.inputSchema).safeParse(args);
+}
+
+function issueText(result: z.ZodSafeParseResult<unknown>): string {
+  return result.success ? '' : result.error.issues.map((issue) => issue.message).join(' ');
+}
+
+function summaryClient(components: Array<Record<string, unknown>>): ToolJetClient {
+  return {
+    getAppSummary: vi.fn().mockResolvedValue({
+      app_id: 'app1',
+      pages: [{ id: 'p1', components }],
+      queries: [],
+      events: [],
+    }),
+    updateComponents: vi.fn().mockResolvedValue({ updated: 1 }),
+    updateLayouts: vi.fn().mockResolvedValue({ updated: 1 }),
+  } as unknown as ToolJetClient;
+}
+
+const textComponent = {
+  id: 'c-title', name: 'title', type: 'Text',
+  properties: { text: { value: 'Old' } }, styles: {},
+  layouts: { desktop: { top: 0, left: 0, width: 20, height: 40 } },
+};
+
+// Regression (observed 2026-09-05): five update_components calls in a row sent `properties` at the
+// top level of each entry instead of under `definition`. zod stripped the unknown key, the PUT body
+// carried `{ component: {} }`, ToolJet answered 200 without writing anything, and the tool reported
+// `{"updated":1}` every time. Nothing persisted and nothing said so.
+describe('update_components strict entries', () => {
+  const tool = updateComponentsTool({} as ToolJetClient);
+
+  it('rejects a top-level properties patch and says to nest it under definition', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      updates: [{ component_id: 'title', properties: { text: 'New' } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/"properties".*under `definition`/i);
+  });
+
+  it.each(['styles', 'validation', 'others', 'general'])('rejects a top-level %s patch', (section) => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      updates: [{ component_id: 'title', [section]: { x: 1 } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(new RegExp(`"${section}".*under \`definition\``, 'i'));
+  });
+
+  it.each(['layout', 'layouts'])('points a top-level %s key at update_layout', (key) => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      updates: [{ component_id: 'title', [key]: { top: 0, left: 0, width: 10, height: 40 } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(new RegExp(`"${key}".*update_layout`, 'i'));
+  });
+
+  it('rejects unknown keys inside definition (e.g. layout) instead of stripping them', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      updates: [{ component_id: 'title', definition: { layout: { top: 0, left: 0, width: 10, height: 40 } } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/definition.*"layout".*update_layout/i);
+  });
+
+  it('still accepts a well-formed definition entry and a rename entry', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      updates: [
+        { component_id: 'title', definition: { properties: { text: 'New' }, styles: { textSize: 20 } } },
+        { component_id: 'other', name: 'renamed' },
+        { component_id: 'third', parent: 'modal1', slot_name: 'header' },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('fails an entry that changes nothing instead of reporting it as updated', async () => {
+    const client = summaryClient([textComponent]);
+    const result = await updateComponentsTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      updates: [{ component_id: 'title' }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/"title".*nothing to update.*definition/i);
+    expect(client.updateComponents).not.toHaveBeenCalled();
+  });
+
+  it('fails an entry whose definition has only empty sections', async () => {
+    const client = summaryClient([textComponent]);
+    const result = await updateComponentsTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      updates: [{ component_id: 'title', definition: { properties: {} } }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/nothing to update/i);
+    expect(client.updateComponents).not.toHaveBeenCalled();
+  });
+
+  it('describes the definition nesting so the model gets the shape right first time', () => {
+    expect(tool.description).toMatch(/unknown.*keys.*rejected|rejected.*unknown/i);
+  });
+});
+
+describe('update_layout strict entries', () => {
+  const tool = updateLayoutTool({} as ToolJetClient);
+
+  it('rejects a bare rect at the top level and says to nest it under desktop/mobile', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      layouts: [{ component_id: 'title', top: 0, left: 0, width: 10, height: 40 }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/"top".*desktop.*mobile/i);
+  });
+
+  it.each(['layout', 'layouts'])('rejects a nested %s wrapper', (key) => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      layouts: [{ component_id: 'title', [key]: { desktop: { top: 0, left: 0, width: 10, height: 40 } } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(new RegExp(`"${key}".*desktop`, 'i'));
+  });
+
+  it('points a definition/properties patch at update_components', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v', page_id: 'p',
+      layouts: [{ component_id: 'title', definition: { properties: { text: 'x' } } }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/"definition".*update_components/i);
+  });
+
+  it('fails an entry with no desktop, mobile, parent or slot_name instead of writing an empty diff', async () => {
+    const client = summaryClient([textComponent]);
+    const result = await updateLayoutTool(client).handler({
+      app_id: 'app1', version_id: 'v1', page_id: 'p1',
+      layouts: [{ component_id: 'title' }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/"title".*nothing to update/i);
+    expect(client.updateLayouts).not.toHaveBeenCalled();
+  });
+});
+
+describe('update_events strict entries', () => {
+  const tool = updateEventsTool({} as ToolJetClient);
+
+  it('rejects action fields at the top level and says to nest them under event', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v',
+      events: [{ event_id: 'e1', name: 'onClick', actionId: 'run-query', queryId: 'q1' }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/"actionId".*under `event`/i);
+  });
+
+  it('still accepts update and reorder entries', () => {
+    expect(parseArgs(tool, {
+      app_id: 'a', version_id: 'v',
+      events: [{ event_id: 'e1', name: 'onClick', event: { eventId: 'onClick', actionId: 'run-query' } }],
+    }).success).toBe(true);
+    expect(parseArgs(tool, {
+      app_id: 'a', version_id: 'v', update_type: 'reorder',
+      events: [{ event_id: 'e1', index: 2 }],
+    }).success).toBe(true);
+  });
+});
+
+describe('update_pages strict entries', () => {
+  const tool = updatePagesTool({} as ToolJetClient);
+
+  it('rejects unknown page fields such as title instead of stripping them', () => {
+    const result = parseArgs(tool, {
+      app_id: 'a', version_id: 'v',
+      updates: [{ page_id: 'p1', title: 'Overview' }],
+    });
+    expect(result.success).toBe(false);
+    expect(issueText(result)).toMatch(/"title".*name.*icon.*hidden/i);
+  });
+
+  it('still accepts name/icon/hidden updates', () => {
+    expect(parseArgs(tool, {
+      app_id: 'a', version_id: 'v',
+      updates: [{ page_id: 'p1', name: 'Overview', icon: 'home', hidden: false }],
+    }).success).toBe(true);
+  });
+});
+
+// Last line of defence: even a caller that bypasses the tool layer can never PUT an empty diff and
+// have it reported as an update.
+describe('client refuses empty update diffs', () => {
+  const config: Config = { apiUrl: 'http://localhost:3000', appUrl: 'http://localhost:8082', email: 'a@b.com', password: 'pw' };
+  function makeAuth(): Auth & { authedFetch: ReturnType<typeof vi.fn> } {
+    return {
+      authedFetch: vi.fn(),
+      getOrganizationId: vi.fn().mockResolvedValue('org1'),
+      getOrganizationSlug: vi.fn().mockResolvedValue('ws'),
+    };
+  }
+
+  it('updateComponents throws when an entry has neither a definition nor a name/parent change', async () => {
+    const auth = makeAuth();
+    const client = createClient(auth, config);
+    await expect(client.updateComponents({
+      appId: 'app1', versionId: 'v1', pageId: 'p1',
+      updates: [{ componentId: 'c-1', definition: {} }],
+    })).rejects.toThrow(/c-1.*nothing to update/i);
+    expect(auth.authedFetch).not.toHaveBeenCalled();
+  });
+
+  it('updateComponents throws when every definition section is empty', async () => {
+    const auth = makeAuth();
+    const client = createClient(auth, config);
+    await expect(client.updateComponents({
+      appId: 'app1', versionId: 'v1', pageId: 'p1',
+      updates: [{ componentId: 'c-1', definition: { properties: {}, styles: {} } }],
+    })).rejects.toThrow(/c-1.*nothing to update/i);
+    expect(auth.authedFetch).not.toHaveBeenCalled();
+  });
+
+  it('updateLayouts throws when an entry has neither a rect nor a parent change', async () => {
+    const auth = makeAuth();
+    const client = createClient(auth, config);
+    await expect(client.updateLayouts({
+      appId: 'app1', versionId: 'v1', pageId: 'p1',
+      layouts: [{ componentId: 'c-1' }],
+    })).rejects.toThrow(/c-1.*nothing to update/i);
+    expect(auth.authedFetch).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: ModalV2 has a real `size` property (sm/md/lg/xl = modal width). The text-size alias
+// table rewrote it to styles.textSize, then a second warning said textSize is unknown for ModalV2.
+describe('size alias is scoped to components with a textSize style', () => {
+  it('leaves ModalV2 properties.size alone and emits no alias warning', () => {
+    const result = normalizeComponentSpec({
+      name: 'detailModal',
+      type: 'ModalV2',
+      properties: { size: 'lg', showHeader: true },
+    } as never);
+    expect((result.component.properties.size as { value: unknown }).value).toBe('lg');
+    expect(result.component.styles?.textSize).toBeUndefined();
+    expect(result.warnings.filter((w) => /size|textSize/i.test(w))).toEqual([]);
+  });
+
+  it('still moves Text properties.size to styles.textSize', () => {
+    const result = normalizeComponentSpec({
+      name: 'title',
+      type: 'Text',
+      properties: { text: 'Hello', size: 24 },
+    } as never);
+    expect(result.component.properties.size).toBeUndefined();
+    expect((result.component.styles?.textSize as { value: unknown }).value).toBe(24);
+    expect(result.warnings.some((w) => /moved alias "size" to styles\.textSize/.test(w))).toBe(true);
+  });
+
+  it('does not alias a key to a style the component type lacks', () => {
+    // Divider has no textColor style; `color` must not be rewritten to a key ToolJet would ignore.
+    const result = normalizeComponentSpec({
+      name: 'rule',
+      type: 'Divider',
+      properties: { color: '#000' },
+    } as never);
+    expect(result.component.styles?.textColor).toBeUndefined();
+    expect(result.warnings.some((w) => /textColor/.test(w))).toBe(false);
+  });
+});


### PR DESCRIPTION
Codex's core reliability work from the Luna real-user benchmark (5 to 6 September). Four commits.

## What changes

- **Strict update entries** (`src/strictEntry.ts`): `update_components`, `update_layout`, `update_events` and `update_pages` reject unknown entry keys with a message that names the fix, and refuse an entry that changes nothing. Observed live on 5 September: a patch placed at the top level was stripped by zod, the PUT carried an empty diff, ToolJet answered 200, and the tool reported `updated: 1` five times in a row with nothing persisted.
- **Property-key aliases scoped** (`size` to `textSize`, `color` to `textColor`) so they fire only when the key is not a real property of the component; ModalV2's `size` is left alone.
- **Binding identities and modal event order** validated before writes.
- **Query aliases resolved** and **partial-phase recovery** reported precisely so a failed apply can be repaired in place instead of replayed.
- Bundle refreshed.

## Tests

`tests/strictUpdateSchemas.test.ts` (289 lines) and `tests/lunaRegression.test.ts` added; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)