### PR TITLE
Publish the ServiceNow response contract and reject .data.result bindings

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -33,9 +33,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../tooljet-mcp/node_modules/content-type/index.js
+// node_modules/content-type/index.js
 var require_content_type = __commonJS({
-  "../tooljet-mcp/node_modules/content-type/index.js"(exports) {
+  "node_modules/content-type/index.js"(exports) {
     "use strict";
     var PARAM_REGEXP = /; *([!#$%&'*+.^_`|~0-9A-Za-z-]+) *= *("(?:[\u000b\u0020\u0021\u0023-\u005b\u005d-\u007e\u0080-\u00ff]|\\[\u000b\u0020-\u00ff])*"|[!#$%&'*+.^_`|~0-9A-Za-z-]+) */g;
     var TEXT_REGEXP = /^[\u000b\u0020-\u007e\u0080-\u00ff]+$/;
@@ -137,9 +137,9 @@ var require_content_type = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.regexpCode = exports.getEsmExportName = exports.getProperty = exports.safeStringify = exports.stringify = exports.strConcat = exports.addCodeArg = exports.str = exports._ = exports.nil = exports._Code = exports.Name = exports.IDENTIFIER = exports._CodeOrName = void 0;
@@ -291,9 +291,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/scope.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.ValueScope = exports.ValueScopeName = exports.Scope = exports.varKinds = exports.UsedValueState = void 0;
@@ -436,9 +436,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/codegen/index.js"(exports) {
+  "node_modules/ajv/dist/compile/codegen/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.or = exports.and = exports.not = exports.CodeGen = exports.operators = exports.varKinds = exports.ValueScopeName = exports.ValueScope = exports.Scope = exports.Name = exports.regexpCode = exports.stringify = exports.getProperty = exports.nil = exports.strConcat = exports.str = exports._ = void 0;
@@ -1156,9 +1156,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/util.js
+// node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/util.js"(exports) {
+  "node_modules/ajv/dist/compile/util.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.checkStrictMode = exports.getErrorPath = exports.Type = exports.useFunc = exports.setEvaluated = exports.evaluatedPropsToName = exports.mergeEvaluated = exports.eachItem = exports.unescapeJsonPointer = exports.escapeJsonPointer = exports.escapeFragment = exports.unescapeFragment = exports.schemaRefOrVal = exports.schemaHasRulesButRef = exports.schemaHasRules = exports.checkUnknownRules = exports.alwaysValidSchema = exports.toHash = void 0;
@@ -1323,9 +1323,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/names.js
+// node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/names.js"(exports) {
+  "node_modules/ajv/dist/compile/names.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1362,9 +1362,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/errors.js"(exports) {
+  "node_modules/ajv/dist/compile/errors.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendErrors = exports.resetErrorsCount = exports.reportExtraError = exports.reportError = exports.keyword$DataError = exports.keywordError = void 0;
@@ -1484,9 +1484,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.boolOrEmptySchema = exports.topBoolOrEmptySchema = void 0;
@@ -1535,9 +1535,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/rules.js"(exports) {
+  "node_modules/ajv/dist/compile/rules.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getRules = exports.isJSONType = void 0;
@@ -1566,9 +1566,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/applicability.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.shouldUseRule = exports.shouldUseGroup = exports.schemaHasRulesForType = void 0;
@@ -1589,9 +1589,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/dataType.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.reportTypeError = exports.checkDataTypes = exports.checkDataType = exports.coerceAndCheckDataType = exports.getJSONTypes = exports.getSchemaTypes = exports.DataType = void 0;
@@ -1773,9 +1773,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/defaults.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.assignDefaults = void 0;
@@ -1810,9 +1810,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/code.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/code.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateUnion = exports.validateArray = exports.usePattern = exports.callValidateCode = exports.schemaProperties = exports.allSchemaProperties = exports.noPropertyInData = exports.propertyInData = exports.isOwnProperty = exports.hasPropFunc = exports.reportMissingProp = exports.checkMissingProp = exports.checkReportMissingProp = void 0;
@@ -1943,9 +1943,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/keyword.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateKeywordUsage = exports.validSchemaType = exports.funcKeywordCode = exports.macroKeywordCode = void 0;
@@ -2061,9 +2061,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/subschema.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.extendSubschemaMode = exports.extendSubschemaData = exports.getSubschema = void 0;
@@ -2144,9 +2144,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../tooljet-mcp/node_modules/fast-deep-equal/index.js"(exports, module) {
+  "node_modules/fast-deep-equal/index.js"(exports, module) {
     "use strict";
     module.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2179,9 +2179,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/json-schema-traverse/index.js
+// node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../tooljet-mcp/node_modules/json-schema-traverse/index.js"(exports, module) {
+  "node_modules/json-schema-traverse/index.js"(exports, module) {
     "use strict";
     var traverse = module.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2267,9 +2267,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/resolve.js"(exports) {
+  "node_modules/ajv/dist/compile/resolve.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getSchemaRefs = exports.resolveUrl = exports.normalizeId = exports._getFullPath = exports.getFullPath = exports.inlineRef = void 0;
@@ -2423,9 +2423,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/validate/index.js"(exports) {
+  "node_modules/ajv/dist/compile/validate/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.getData = exports.KeywordCxt = exports.validateFunctionCode = void 0;
@@ -2931,9 +2931,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/runtime/validation_error.js"(exports) {
+  "node_modules/ajv/dist/runtime/validation_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2947,9 +2947,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/ref_error.js"(exports) {
+  "node_modules/ajv/dist/compile/ref_error.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2964,9 +2964,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/compile/index.js
+// node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/compile/index.js"(exports) {
+  "node_modules/ajv/dist/compile/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.resolveSchema = exports.getCompilingSchema = exports.resolveRef = exports.compileSchema = exports.SchemaEnv = void 0;
@@ -3188,9 +3188,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/refs/data.json
+// node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/refs/data.json"(exports, module) {
+  "node_modules/ajv/dist/refs/data.json"(exports, module) {
     module.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3207,9 +3207,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../tooljet-mcp/node_modules/fast-uri/lib/utils.js"(exports, module) {
+  "node_modules/fast-uri/lib/utils.js"(exports, module) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3520,9 +3520,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../tooljet-mcp/node_modules/fast-uri/lib/schemes.js"(exports, module) {
+  "node_modules/fast-uri/lib/schemes.js"(exports, module) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3730,9 +3730,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../tooljet-mcp/node_modules/fast-uri/index.js"(exports, module) {
+  "node_modules/fast-uri/index.js"(exports, module) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizePercentEncoding, normalizePathEncoding, escapePreservingEscapes, reescapeHostDelimiters, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -4042,9 +4042,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/runtime/uri.js"(exports) {
+  "node_modules/ajv/dist/runtime/uri.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -4053,9 +4053,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/core.js
+// node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/core.js"(exports) {
+  "node_modules/ajv/dist/core.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = void 0;
@@ -4664,9 +4664,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/id.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var def = {
@@ -4679,9 +4679,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.callRef = exports.getValidate = void 0;
@@ -4801,9 +4801,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/core/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4822,9 +4822,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4854,9 +4854,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4882,9 +4882,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
+  "node_modules/ajv/dist/runtime/ucs2length.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4908,9 +4908,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4940,9 +4940,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4977,9 +4977,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5006,9 +5006,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5088,9 +5088,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5117,9 +5117,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/runtime/equal.js"(exports) {
+  "node_modules/ajv/dist/runtime/equal.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -5128,9 +5128,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -5195,9 +5195,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5224,9 +5224,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5273,9 +5273,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5311,9 +5311,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateAdditionalItems = void 0;
@@ -5364,9 +5364,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateTuple = void 0;
@@ -5421,9 +5421,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5438,9 +5438,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5473,9 +5473,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5567,9 +5567,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.validateSchemaDeps = exports.validatePropertyDeps = exports.error = void 0;
@@ -5661,9 +5661,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5704,9 +5704,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5810,9 +5810,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5868,9 +5868,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5942,9 +5942,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5973,9 +5973,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5990,9 +5990,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6048,9 +6048,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -6075,9 +6075,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6144,9 +6144,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var util_1 = require_util();
@@ -6162,9 +6162,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -6210,9 +6210,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/format.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6300,9 +6300,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/format/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6311,9 +6311,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/metadata.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.contentVocabulary = exports.metadataVocabulary = void 0;
@@ -6334,9 +6334,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/draft7.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6356,9 +6356,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.DiscrError = void 0;
@@ -6370,9 +6370,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
+  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6475,9 +6475,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
+  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports, module) {
     module.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6632,9 +6632,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv/dist/ajv.js
+// node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../tooljet-mcp/node_modules/ajv/dist/ajv.js"(exports, module) {
+  "node_modules/ajv/dist/ajv.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.MissingRefError = exports.ValidationError = exports.CodeGen = exports.Name = exports.nil = exports.stringify = exports.str = exports._ = exports.KeywordCxt = exports.Ajv = void 0;
@@ -6702,9 +6702,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../tooljet-mcp/node_modules/ajv-formats/dist/formats.js"(exports) {
+  "node_modules/ajv-formats/dist/formats.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatNames = exports.fastFormats = exports.fullFormats = void 0;
@@ -6905,9 +6905,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../tooljet-mcp/node_modules/ajv-formats/dist/limit.js"(exports) {
+  "node_modules/ajv-formats/dist/limit.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.formatLimitDefinition = void 0;
@@ -6977,9 +6977,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../tooljet-mcp/node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../tooljet-mcp/node_modules/ajv-formats/dist/index.js"(exports, module) {
+  "node_modules/ajv-formats/dist/index.js"(exports, module) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -7024,10 +7024,10 @@ import { createServer } from "node:http";
 import { realpathSync } from "node:fs";
 import { fileURLToPath as fileURLToPath5 } from "node:url";
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 import process3 from "node:process";
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 var external_exports = {};
 __export(external_exports, {
   $brand: () => $brand,
@@ -7270,7 +7270,7 @@ __export(external_exports, {
   xor: () => xor
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/core/index.js
+// node_modules/zod/v4/core/index.js
 var core_exports2 = {};
 __export(core_exports2, {
   $ZodAny: () => $ZodAny,
@@ -7549,7 +7549,7 @@ __export(core_exports2, {
   version: () => version
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var _a;
 var NEVER = /* @__PURE__ */ Object.freeze({
   status: "aborted"
@@ -7626,7 +7626,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -8322,7 +8322,7 @@ var Class = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -8461,7 +8461,7 @@ function prettifyError(error51) {
   return lines.join("\n");
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -8549,7 +8549,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
 };
 var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
 
-// ../tooljet-mcp/node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -8708,7 +8708,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../tooljet-mcp/node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a3;
   inst._zod ?? (inst._zod = {});
@@ -9256,7 +9256,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -9292,14 +9292,14 @@ var Doc = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 4,
   patch: 3
 };
 
-// ../tooljet-mcp/node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a3;
   inst ?? (inst = {});
@@ -11392,7 +11392,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/index.js
+// node_modules/zod/v4/locales/index.js
 var locales_exports = {};
 __export(locales_exports, {
   ar: () => ar_default,
@@ -11449,7 +11449,7 @@ __export(locales_exports, {
   zhTW: () => zh_TW_default
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ar.js
+// node_modules/zod/v4/locales/ar.js
 var error = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -11556,7 +11556,7 @@ function ar_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/az.js
+// node_modules/zod/v4/locales/az.js
 var error2 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
@@ -11662,7 +11662,7 @@ function az_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/be.js
+// node_modules/zod/v4/locales/be.js
 function getBelarusianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -11819,7 +11819,7 @@ function be_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/bg.js
+// node_modules/zod/v4/locales/bg.js
 var error4 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0430", verb: "\u0434\u0430 \u0441\u044A\u0434\u044A\u0440\u0436\u0430" },
@@ -11940,7 +11940,7 @@ function bg_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ca.js
+// node_modules/zod/v4/locales/ca.js
 var error5 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
@@ -12049,7 +12049,7 @@ function ca_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/cs.js
+// node_modules/zod/v4/locales/cs.js
 var error6 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
@@ -12161,7 +12161,7 @@ function cs_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/da.js
+// node_modules/zod/v4/locales/da.js
 var error7 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
@@ -12277,7 +12277,7 @@ function da_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/de.js
+// node_modules/zod/v4/locales/de.js
 var error8 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
@@ -12386,7 +12386,7 @@ function de_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/el.js
+// node_modules/zod/v4/locales/el.js
 var error9 = () => {
   const Sizable = {
     string: { unit: "\u03C7\u03B1\u03C1\u03B1\u03BA\u03C4\u03AE\u03C1\u03B5\u03C2", verb: "\u03BD\u03B1 \u03AD\u03C7\u03B5\u03B9" },
@@ -12496,7 +12496,7 @@ function el_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error10 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -12609,7 +12609,7 @@ function en_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/eo.js
+// node_modules/zod/v4/locales/eo.js
 var error11 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
@@ -12719,7 +12719,7 @@ function eo_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/es.js
+// node_modules/zod/v4/locales/es.js
 var error12 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
@@ -12852,7 +12852,7 @@ function es_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/fa.js
+// node_modules/zod/v4/locales/fa.js
 var error13 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -12967,7 +12967,7 @@ function fa_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/fi.js
+// node_modules/zod/v4/locales/fi.js
 var error14 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
@@ -13080,7 +13080,7 @@ function fi_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/fr.js
+// node_modules/zod/v4/locales/fr.js
 var error15 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -13206,7 +13206,7 @@ function fr_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/fr-CA.js
+// node_modules/zod/v4/locales/fr-CA.js
 var error16 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -13314,7 +13314,7 @@ function fr_CA_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/he.js
+// node_modules/zod/v4/locales/he.js
 var error17 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
@@ -13509,7 +13509,7 @@ function he_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/hr.js
+// node_modules/zod/v4/locales/hr.js
 var error18 = () => {
   const Sizable = {
     string: { unit: "znakova", verb: "imati" },
@@ -13632,7 +13632,7 @@ function hr_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/hu.js
+// node_modules/zod/v4/locales/hu.js
 var error19 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
@@ -13741,7 +13741,7 @@ function hu_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/hy.js
+// node_modules/zod/v4/locales/hy.js
 function getArmenianPlural(count, one, many) {
   return Math.abs(count) === 1 ? one : many;
 }
@@ -13889,7 +13889,7 @@ function hy_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/id.js
+// node_modules/zod/v4/locales/id.js
 var error21 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
@@ -13996,7 +13996,7 @@ function id_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/is.js
+// node_modules/zod/v4/locales/is.js
 var error22 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
@@ -14106,7 +14106,7 @@ function is_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/it.js
+// node_modules/zod/v4/locales/it.js
 var error23 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
@@ -14215,7 +14215,7 @@ function it_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ja.js
+// node_modules/zod/v4/locales/ja.js
 var error24 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
@@ -14323,7 +14323,7 @@ function ja_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ka.js
+// node_modules/zod/v4/locales/ka.js
 var error25 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -14436,7 +14436,7 @@ function ka_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/km.js
+// node_modules/zod/v4/locales/km.js
 var error26 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -14547,12 +14547,12 @@ function km_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/kh.js
+// node_modules/zod/v4/locales/kh.js
 function kh_default() {
   return km_default();
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ko.js
+// node_modules/zod/v4/locales/ko.js
 var error27 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
@@ -14664,7 +14664,7 @@ function ko_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/lt.js
+// node_modules/zod/v4/locales/lt.js
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
 };
@@ -14868,7 +14868,7 @@ function lt_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/mk.js
+// node_modules/zod/v4/locales/mk.js
 var error29 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -14978,7 +14978,7 @@ function mk_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ms.js
+// node_modules/zod/v4/locales/ms.js
 var error30 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
@@ -15086,7 +15086,7 @@ function ms_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/nl.js
+// node_modules/zod/v4/locales/nl.js
 var error31 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
@@ -15197,7 +15197,7 @@ function nl_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/no.js
+// node_modules/zod/v4/locales/no.js
 var error32 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
@@ -15306,7 +15306,7 @@ function no_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ota.js
+// node_modules/zod/v4/locales/ota.js
 var error33 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
@@ -15416,7 +15416,7 @@ function ota_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ps.js
+// node_modules/zod/v4/locales/ps.js
 var error34 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
@@ -15531,7 +15531,7 @@ function ps_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/pl.js
+// node_modules/zod/v4/locales/pl.js
 var error35 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
@@ -15641,7 +15641,7 @@ function pl_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/pt.js
+// node_modules/zod/v4/locales/pt.js
 var error36 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
@@ -15750,7 +15750,7 @@ function pt_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ro.js
+// node_modules/zod/v4/locales/ro.js
 var error37 = () => {
   const Sizable = {
     string: { unit: "caractere", verb: "s\u0103 aib\u0103" },
@@ -15870,7 +15870,7 @@ function ro_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ru.js
+// node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -16027,7 +16027,7 @@ function ru_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/sl.js
+// node_modules/zod/v4/locales/sl.js
 var error39 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
@@ -16137,7 +16137,7 @@ function sl_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/sv.js
+// node_modules/zod/v4/locales/sv.js
 var error40 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
@@ -16248,7 +16248,7 @@ function sv_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ta.js
+// node_modules/zod/v4/locales/ta.js
 var error41 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -16359,7 +16359,7 @@ function ta_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/th.js
+// node_modules/zod/v4/locales/th.js
 var error42 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -16470,7 +16470,7 @@ function th_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/tr.js
+// node_modules/zod/v4/locales/tr.js
 var error43 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
@@ -16576,7 +16576,7 @@ function tr_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/uk.js
+// node_modules/zod/v4/locales/uk.js
 var error44 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -16685,12 +16685,12 @@ function uk_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ua.js
+// node_modules/zod/v4/locales/ua.js
 function ua_default() {
   return uk_default();
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/ur.js
+// node_modules/zod/v4/locales/ur.js
 var error45 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
@@ -16801,7 +16801,7 @@ function ur_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/uz.js
+// node_modules/zod/v4/locales/uz.js
 var error46 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
@@ -16912,7 +16912,7 @@ function uz_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/vi.js
+// node_modules/zod/v4/locales/vi.js
 var error47 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
@@ -17021,7 +17021,7 @@ function vi_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/zh-CN.js
+// node_modules/zod/v4/locales/zh-CN.js
 var error48 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
@@ -17131,7 +17131,7 @@ function zh_CN_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/zh-TW.js
+// node_modules/zod/v4/locales/zh-TW.js
 var error49 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
@@ -17239,7 +17239,7 @@ function zh_TW_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/locales/yo.js
+// node_modules/zod/v4/locales/yo.js
 var error50 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
@@ -17347,7 +17347,7 @@ function yo_default() {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a2;
 var $output = /* @__PURE__ */ Symbol("ZodOutput");
 var $input = /* @__PURE__ */ Symbol("ZodInput");
@@ -17397,7 +17397,7 @@ function registry() {
 (_a2 = globalThis).__zod_globalRegistry ?? (_a2.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../tooljet-mcp/node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -18436,7 +18436,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -18795,7 +18795,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../tooljet-mcp/node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -19339,7 +19339,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/core/json-schema-generator.js
+// node_modules/zod/v4/core/json-schema-generator.js
 var JSONSchemaGenerator = class {
   /** @deprecated Access via ctx instead */
   get metadataRegistry() {
@@ -19414,10 +19414,10 @@ var JSONSchemaGenerator = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod/v4/core/json-schema.js
+// node_modules/zod/v4/core/json-schema.js
 var json_schema_exports = {};
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var schemas_exports2 = {};
 __export(schemas_exports2, {
   ZodAny: () => ZodAny,
@@ -19588,7 +19588,7 @@ __export(schemas_exports2, {
   xor: () => xor
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/checks.js
+// node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -19622,7 +19622,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports = {};
 __export(iso_exports, {
   ZodISODate: () => ZodISODate,
@@ -19663,7 +19663,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -19703,7 +19703,7 @@ var ZodRealError = /* @__PURE__ */ $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse2 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -19717,7 +19717,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var _installedGroups = /* @__PURE__ */ new WeakMap();
 function _installLazyMethods(inst, group, methods) {
   const proto = Object.getPrototypeOf(inst);
@@ -21007,7 +21007,7 @@ function preprocess(fn, schema) {
   });
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/compat.js
+// node_modules/zod/v4/classic/compat.js
 var ZodIssueCode = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -21033,7 +21033,7 @@ var ZodFirstPartyTypeKind;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/from-json-schema.js
+// node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports2,
   ...checks_exports2,
@@ -21513,7 +21513,7 @@ function fromJSONSchema(schema, params) {
   return convertSchema(normalized2, ctx);
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/coerce.js
+// node_modules/zod/v4/classic/coerce.js
 var coerce_exports = {};
 __export(coerce_exports, {
   bigint: () => bigint3,
@@ -21538,10 +21538,10 @@ function date4(params) {
   return _coercedDate(ZodDate, params);
 }
 
-// ../tooljet-mcp/node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default());
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -23074,7 +23074,7 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var STDIO_DEFAULT_MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 var ReadBuffer = class {
   constructor(options2) {
@@ -23111,7 +23111,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = process3.stdin, _stdout = process3.stdout, options2) {
     this._stdin = _stdin;
@@ -23178,14 +23178,14 @@ var StdioServerTransport = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/@hono/node-server/dist/constants-BLSFu_RU.mjs
+// node_modules/@hono/node-server/dist/constants-BLSFu_RU.mjs
 var X_ALREADY_SENT = "x-hono-already-sent";
 
-// ../tooljet-mcp/node_modules/@hono/node-server/dist/index.mjs
+// node_modules/@hono/node-server/dist/index.mjs
 import { Http2ServerRequest, constants } from "node:http2";
 import { Readable } from "node:stream";
 
-// ../tooljet-mcp/node_modules/hono/dist/helper/websocket/index.js
+// node_modules/hono/dist/helper/websocket/index.js
 var defineWebSocketHelper = (handler) => {
   return ((...args) => {
     if (typeof args[0] === "function") {
@@ -23211,7 +23211,7 @@ var defineWebSocketHelper = (handler) => {
   });
 };
 
-// ../tooljet-mcp/node_modules/@hono/node-server/dist/index.mjs
+// node_modules/@hono/node-server/dist/index.mjs
 var RequestError = class extends Error {
   constructor(message, options2) {
     super(message, options2);
@@ -24356,7 +24356,7 @@ var upgradeWebSocket = defineWebSocketHelper(async (c, events, options2) => {
   return new Response();
 });
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/mediaType.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/mediaType.js
 var import_content_type = __toESM(require_content_type(), 1);
 function mediaTypeEssence(header) {
   if (!header) {
@@ -24379,7 +24379,7 @@ function isJsonContentType(header) {
   return mediaTypeEssence(header) === "application/json";
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/sseKeepAlive.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/sseKeepAlive.js
 var DEFAULT_SSE_KEEP_ALIVE_MS = 15e3;
 var MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 function armSseKeepAlive(intervalMs, onTick) {
@@ -24391,7 +24391,7 @@ function armSseKeepAlive(intervalMs, onTick) {
   return timer;
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options2 = {}) {
     this._started = false;
@@ -25123,7 +25123,7 @@ data:
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js
 var StreamableHTTPServerTransport = class {
   constructor(options2 = {}) {
     this._requestContext = /* @__PURE__ */ new WeakMap();
@@ -25225,7 +25225,7 @@ var StreamableHTTPServerTransport = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -25359,7 +25359,7 @@ var getParsedType2 = (data) => {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode2 = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -25473,7 +25473,7 @@ ZodError2.create = (issues) => {
   return error51;
 };
 
-// ../tooljet-mcp/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -25576,13 +25576,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default2 = errorMap;
 
-// ../tooljet-mcp/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default2;
 function getErrorMap2() {
   return overrideErrorMap;
 }
 
-// ../tooljet-mcp/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -25691,14 +25691,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../tooljet-mcp/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../tooljet-mcp/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -29101,7 +29101,7 @@ var nullableType = ZodNullable2.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../tooljet-mcp/node_modules/zod/v4/mini/schemas.js
+// node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -29147,7 +29147,7 @@ function object2(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -29307,12 +29307,12 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = /* @__PURE__ */ Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -29346,7 +29346,7 @@ var getDefaultOptions = (options2) => typeof options2 === "string" ? {
   ...options2
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/Refs.js
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options2) => {
   const _options = getDefaultOptions(options2);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -29367,7 +29367,7 @@ var getRefs = (options2) => {
   };
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage, refs2) {
   if (!refs2?.errorMessages)
     return;
@@ -29383,7 +29383,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage, refs2) {
   addErrorMessage(res, key, errorMessage, refs2);
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -29393,7 +29393,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs2) {
   if (refs2.target !== "openAi") {
     return {};
@@ -29409,7 +29409,7 @@ function parseAnyDef(refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs2) {
   const res = {
     type: "array"
@@ -29433,7 +29433,7 @@ function parseArrayDef(def, refs2) {
   return res;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs2) {
   const res = {
     type: "integer",
@@ -29479,24 +29479,24 @@ function parseBigintDef(def, refs2) {
   return res;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs2) {
   return parseDef(_def.type._def, refs2);
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs2) => {
   return parseDef(def.innerType._def, refs2);
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs2, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs2.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -29555,7 +29555,7 @@ var integerDateParser = (def, refs2) => {
   return res;
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs2) {
   return {
     ...parseDef(_def.innerType._def, refs2),
@@ -29563,12 +29563,12 @@ function parseDefaultDef(_def, refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs2) {
   return refs2.effectStrategy === "input" ? parseDef(_def.schema._def, refs2) : parseAnyDef(refs2);
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -29576,7 +29576,7 @@ function parseEnumDef(def) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -29618,7 +29618,7 @@ function parseIntersectionDef(def, refs2) {
   } : void 0;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs2) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -29638,7 +29638,7 @@ function parseLiteralDef(def, refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -29963,7 +29963,7 @@ function stringifyRegExpWithFlags(regex, refs2) {
   return pattern;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs2) {
   if (refs2.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -30015,7 +30015,7 @@ function parseRecordDef(def, refs2) {
   return schema;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs2) {
   if (refs2.mapStrategy === "record") {
     return parseRecordDef(def, refs2);
@@ -30040,7 +30040,7 @@ function parseMapDef(def, refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -30054,7 +30054,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs2) {
   return refs2.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -30064,7 +30064,7 @@ function parseNeverDef(refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs2) {
   return refs2.target === "openApi3" ? {
     enum: ["null"],
@@ -30074,7 +30074,7 @@ function parseNullDef(refs2) {
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -30142,7 +30142,7 @@ var asAnyOf = (def, refs2) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs2) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs2.target === "openApi3") {
@@ -30174,7 +30174,7 @@ function parseNullableDef(def, refs2) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs2) {
   const res = {
     type: "number"
@@ -30223,7 +30223,7 @@ function parseNumberDef(def, refs2) {
   return res;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs2) {
   const forceOptionalIntoNullable = refs2.target === "openAi";
   const result = {
@@ -30293,7 +30293,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs2) => {
   if (refs2.currentPath.toString() === refs2.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs2);
@@ -30312,7 +30312,7 @@ var parseOptionalDef = (def, refs2) => {
   } : parseAnyDef(refs2);
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs2) => {
   if (refs2.pipeStrategy === "input") {
     return parseDef(def.in._def, refs2);
@@ -30332,12 +30332,12 @@ var parsePipelineDef = (def, refs2) => {
   };
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs2) {
   return parseDef(def.type._def, refs2);
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs2) {
   const items = parseDef(def.valueType._def, {
     ...refs2,
@@ -30357,7 +30357,7 @@ function parseSetDef(def, refs2) {
   return schema;
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs2) {
   if (def.rest) {
     return {
@@ -30385,24 +30385,24 @@ function parseTupleDef(def, refs2) {
   }
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs2) {
   return {
     not: parseAnyDef(refs2)
   };
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs2) {
   return parseAnyDef(refs2);
 }
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs2) => {
   return parseDef(def.innerType._def, refs2);
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs2) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind2.ZodString:
@@ -30478,7 +30478,7 @@ var selectParser = (def, typeName, refs2) => {
   }
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs2, forceResolution = false) {
   const seenItem = refs2.seen.get(def);
   if (refs2.override) {
@@ -30534,7 +30534,7 @@ var addMeta = (def, refs2, jsonSchema) => {
   return jsonSchema;
 };
 
-// ../tooljet-mcp/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options2) => {
   const refs2 = getRefs(options2);
   let definitions = typeof options2 === "object" && options2.definitions ? Object.entries(options2.definitions).reduce((acc, [name2, schema2]) => ({
@@ -30596,7 +30596,7 @@ var zodToJsonSchema = (schema, options2) => {
   return combined;
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -30638,7 +30638,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -31592,7 +31592,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -31660,7 +31660,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -31873,7 +31873,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -31908,7 +31908,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -32279,7 +32279,7 @@ var Server = class extends Protocol {
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = /* @__PURE__ */ Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -32293,7 +32293,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -32351,7 +32351,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -32366,7 +32366,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// ../tooljet-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options2) {
     this._registeredResources = {};
@@ -36031,6 +36031,19 @@ function validateAppStructure(summary) {
     }
     for (const name of bad) {
       errors.push(`${component.type} "${component.name ?? component.id}": reads queries.${name}.data, but "${name}" is a ToolJet DB sql_execution query whose data is {results: rows}. Bind queries.${name}.data.results (or data.results[0].<column> for a single value), or the component shows No data.`);
+    }
+  }
+  for (const component of allComponents) {
+    const blob = JSON.stringify(component.properties ?? "");
+    const bad = /* @__PURE__ */ new Set();
+    for (const m of blob.matchAll(/\bqueries\.([A-Za-z_][A-Za-z0-9_]*)\??\.data\??\.result\b/g)) {
+      const query = queryByName.get(m[1]);
+      if (!query || query.kind !== "servicenow")
+        continue;
+      bad.add(m[1]);
+    }
+    for (const name of bad) {
+      errors.push(`${component.type ?? "Component"} "${component.name ?? component.id}": reads queries.${name}.data.result, but "${name}" is a ServiceNow query and the plugin already unwraps the REST result envelope: queries.<q>.data is the records array (or the record for get/create/update). Bind queries.${name}.data instead, or the component shows No data.`);
     }
   }
   for (const component of allComponents) {

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -36040,6 +36040,8 @@ function validateAppStructure(summary) {
       const query = queryByName.get(m[1]);
       if (!query || query.kind !== "servicenow")
         continue;
+      if (isTruthyBinding(propVal2(recordValue(query.options), "enableTransformation")))
+        continue;
       bad.add(m[1]);
     }
     for (const name of bad) {

--- a/data/datasource-contract-overrides.json
+++ b/data/datasource-contract-overrides.json
@@ -268,5 +268,54 @@
         ]
       }
     }
+  },
+  "servicenow": {
+    "response_groups": [
+      {
+        "operations": ["list_records"],
+        "response": {
+          "type": "array<object>",
+          "description": "The records themselves. The plugin unwraps ServiceNow's REST envelope, so queries.<q>.data IS the array; never bind queries.<q>.data.result. With sysparm_display_value=true, reference fields such as assignment_group, caller_id and assigned_to are objects { display_value, link }: bind <field>.display_value, or request sysparm_display_value=false to get sys_ids, or 'all' to get both."
+        }
+      },
+      {
+        "operations": ["get_record", "create_record", "update_record"],
+        "response": {
+          "type": "object",
+          "description": "The single record (ServiceNow's result object, unwrapped): bind queries.<q>.data.<field>, never data.result.<field>. Reference fields follow the same sysparm_display_value rule as list_records."
+        }
+      },
+      {
+        "operations": ["delete_record"],
+        "response": { "type": "object", "description": "Empty object on success (ServiceNow returns 204)." }
+      },
+      {
+        "operations": ["aggregate"],
+        "response": {
+          "type": "object",
+          "description": "ServiceNow stats result, unwrapped: data.stats.count (a string), data.stats.avg/sum/min/max keyed by field, or an array of { stats, groupby_fields } when sysparm_group_by is set."
+        }
+      },
+      {
+        "operations": ["list_tables", "get_table_schema", "get_field_choices"],
+        "response": { "type": "array<object>", "description": "Metadata rows, unwrapped from ServiceNow's result envelope." }
+      },
+      {
+        "operations": ["list_workflows", "list_flows"],
+        "response": { "type": "array<object>", "description": "Workflow or flow definitions, unwrapped." }
+      },
+      {
+        "operations": ["invoke_workflow", "trigger_flow"],
+        "response": { "type": "object", "description": "Flow API response; outputs are at queries.<q>.data.outputs, not data.result.outputs." }
+      }
+    ],
+    "operations": {
+      "list_records": {
+        "notes": [
+          "Bind tables to queries.<q>.data directly. The REST `result` wrapper does not exist in ToolJet: queries.<q>.data.result is undefined and the table shows No data.",
+          "Every read must set a sysparm_limit; use sysparm_query for filters (for example active=true^priorityIN1,2) and sysparm_fields to keep rows small."
+        ]
+      }
+    }
   }
 }

--- a/data/datasource-contract-overrides.json
+++ b/data/datasource-contract-overrides.json
@@ -305,7 +305,14 @@
         "response": { "type": "array<object>", "description": "Workflow or flow definitions, unwrapped." }
       },
       {
-        "operations": ["invoke_workflow", "trigger_flow"],
+        "operations": ["invoke_workflow"],
+        "response": {
+          "type": "object",
+          "description": "The MCP tools/call result, returned directly: queries.<q>.data.content contains the content blocks, and data.structuredContent may contain structured output when supplied by the workflow tool. Inspect the returned content before extracting workflow outputs; the plugin does not parse text blocks or expose outputs at data.outputs."
+        }
+      },
+      {
+        "operations": ["trigger_flow"],
         "response": { "type": "object", "description": "Flow API response; outputs are at queries.<q>.data.outputs, not data.result.outputs." }
       }
     ],

--- a/data/datasource-coverage.json
+++ b/data/datasource-coverage.json
@@ -32,11 +32,11 @@
   ],
   "response_contracts": {
     "total": 470,
-    "known": 64,
+    "known": 77,
     "runtime_dependent": 35,
-    "unknown": 371,
+    "unknown": 358,
     "missing": 0,
-    "known_percent": 13.6
+    "known_percent": 16.4
   },
   "known_response_kinds": [
     "anthropic",
@@ -46,6 +46,7 @@
     "mysql",
     "openai",
     "postgresql",
+    "servicenow",
     "snowflake",
     "tooljetdb"
   ],
@@ -123,7 +124,6 @@
     "salesforce": 2,
     "saphana": 1,
     "sendgrid": 1,
-    "servicenow": 13,
     "sharepoint": 1,
     "slack": 2,
     "smtp": 1,

--- a/data/datasource-schemas.json
+++ b/data/datasource-schemas.json
@@ -47732,7 +47732,7 @@
           "status": "known",
           "source": "curated-tooljet-source",
           "type": "object",
-          "description": "Flow API response; outputs are at queries.<q>.data.outputs, not data.result.outputs."
+          "description": "The MCP tools/call result, returned directly: queries.<q>.data.content contains the content blocks, and data.structuredContent may contain structured output when supplied by the workflow tool. Inspect the returned content before extracting workflow outputs; the plugin does not parse text blocks or expose outputs at data.outputs."
         }
       },
       "list_flows": {

--- a/data/datasource-schemas.json
+++ b/data/datasource-schemas.json
@@ -27527,7 +27527,8 @@
           "Users": "@spec/microsoft_graph/users",
           "Teams": "@spec/microsoft_graph/teams",
           "OneDrive": "@spec/microsoft_graph/onedrive",
-          "SharePoint": "@spec/microsoft_graph/sharepoint"
+          "SharePoint": "@spec/microsoft_graph/sharepoint",
+          "OneNote": "@spec/microsoft_graph/onenote"
         }
       }
     },
@@ -47369,10 +47370,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "ServiceNow stats result, unwrapped: data.stats.count (a string), data.stats.avg/sum/min/max keyed by field, or an array of { stats, groupby_fields } when sysparm_group_by is set."
         }
       },
       "create_record": {
@@ -47425,10 +47426,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "The single record (ServiceNow's result object, unwrapped): bind queries.<q>.data.<field>, never data.result.<field>. Reference fields follow the same sysparm_display_value rule as list_records."
         }
       },
       "delete_record": {
@@ -47481,10 +47482,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "Empty object on success (ServiceNow returns 204)."
         }
       },
       "get_field_choices": {
@@ -47543,10 +47544,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "Metadata rows, unwrapped from ServiceNow's result envelope."
         }
       },
       "get_record": {
@@ -47616,10 +47617,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "The single record (ServiceNow's result object, unwrapped): bind queries.<q>.data.<field>, never data.result.<field>. Reference fields follow the same sysparm_display_value rule as list_records."
         }
       },
       "get_table_schema": {
@@ -47672,10 +47673,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "Metadata rows, unwrapped from ServiceNow's result envelope."
         }
       },
       "invoke_workflow": {
@@ -47728,10 +47729,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "Flow API response; outputs are at queries.<q>.data.outputs, not data.result.outputs."
         }
       },
       "list_flows": {
@@ -47784,10 +47785,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "Workflow or flow definitions, unwrapped."
         }
       },
       "list_records": {
@@ -47869,11 +47870,15 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
-        }
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "The records themselves. The plugin unwraps ServiceNow's REST envelope, so queries.<q>.data IS the array; never bind queries.<q>.data.result. With sysparm_display_value=true, reference fields such as assignment_group, caller_id and assigned_to are objects { display_value, link }: bind <field>.display_value, or request sysparm_display_value=false to get sys_ids, or 'all' to get both."
+        },
+        "notes": [
+          "Bind tables to queries.<q>.data directly. The REST `result` wrapper does not exist in ToolJet: queries.<q>.data.result is undefined and the table shows No data.",
+          "Every read must set a sysparm_limit; use sysparm_query for filters (for example active=true^priorityIN1,2) and sysparm_fields to keep rows small."
+        ]
       },
       "list_tables": {
         "operation": "list_tables",
@@ -47925,10 +47930,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "Metadata rows, unwrapped from ServiceNow's result envelope."
         }
       },
       "list_workflows": {
@@ -47975,10 +47980,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "array<object>",
+          "description": "Workflow or flow definitions, unwrapped."
         }
       },
       "trigger_flow": {
@@ -48031,10 +48036,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "Flow API response; outputs are at queries.<q>.data.outputs, not data.result.outputs."
         }
       },
       "update_record": {
@@ -48093,10 +48098,10 @@
           }
         ],
         "response": {
-          "type": "unknown",
-          "status": "unknown",
-          "source": "tooljet-api-plugin",
-          "description": "No stable response shape has been curated from this ToolJet plugin yet. Inspect a safe successful run before binding nested fields."
+          "status": "known",
+          "source": "curated-tooljet-source",
+          "type": "object",
+          "description": "The single record (ServiceNow's result object, unwrapped): bind queries.<q>.data.<field>, never data.result.<field>. Reference fields follow the same sysparm_display_value rule as list_records."
         }
       }
     },
@@ -52818,8 +52823,8 @@
               },
               "sql_execution.sqlQuery": {
                 "path": "sql_execution.sqlQuery",
-                "description": "ToolJet DB SQL reads return data: {results: rows}; bind tables/charts to queries.<name>.data.results and KPIs to data.results[0]. Inspect the actual result before binding; list_rows and other datasource operations can use different shapes.",
-                "type": "string"
+                "type": "string",
+                "description": "ToolJet DB SQL reads return data: {results: rows}; bind tables/charts to queries.<name>.data.results and KPIs to data.results[0]. Inspect the actual result before binding; list_rows and other datasource operations can use different shapes."
               }
             },
             "required": [

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -2017,6 +2017,27 @@ export function validateAppStructure(summary: AppSummary): LintResult {
     }
   }
 
+  // ServiceNow unwraps the REST `result` envelope: queries.q.data is the rows array (or the record), so a
+  // binding to `.data.result` is always undefined. Observed live (model-guide benchmark, 2026-09-07): Luna max,
+  // Luna high and Gemini Pro bound every incident list to data.result from memory of the raw REST API and
+  // rendered empty queues although the queries returned 16 to 40 incidents.
+  for (const component of allComponents) {
+    const blob = JSON.stringify(component.properties ?? '');
+    const bad = new Set<string>();
+    for (const m of blob.matchAll(/\bqueries\.([A-Za-z_][A-Za-z0-9_]*)\??\.data\??\.result\b/g)) {
+      const query = queryByName.get(m[1]!);
+      if (!query || query.kind !== 'servicenow') continue;
+      bad.add(m[1]!);
+    }
+    for (const name of bad) {
+      errors.push(
+        `${component.type ?? 'Component'} "${component.name ?? component.id}": reads queries.${name}.data.result, but "${name}" is a ` +
+          'ServiceNow query and the plugin already unwraps the REST result envelope: queries.<q>.data is the records array ' +
+          `(or the record for get/create/update). Bind queries.${name}.data instead, or the component shows No data.`
+      );
+    }
+  }
+
   // A query referenced by bare name. Observed live (Haiku, Helix benchmark 2026-09-07): `jobsWaitingLongest.data`
   // instead of `queries.jobsWaitingLongest.data`, which is an undefined identifier at runtime, so the table
   // showed No data while the query itself was fine. Component references are excluded by the lookbehind

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -2017,8 +2017,8 @@ export function validateAppStructure(summary: AppSummary): LintResult {
     }
   }
 
-  // ServiceNow unwraps the REST `result` envelope: queries.q.data is the rows array (or the record), so a
-  // binding to `.data.result` is always undefined. Observed live (model-guide benchmark, 2026-09-07): Luna max,
+  // ServiceNow unwraps the REST `result` envelope: without a transformation, queries.q.data is the rows
+  // array (or the record). Observed live (model-guide benchmark, 2026-09-07): Luna max,
   // Luna high and Gemini Pro bound every incident list to data.result from memory of the raw REST API and
   // rendered empty queues although the queries returned 16 to 40 incidents.
   for (const component of allComponents) {
@@ -2027,6 +2027,8 @@ export function validateAppStructure(summary: AppSummary): LintResult {
     for (const m of blob.matchAll(/\bqueries\.([A-Za-z_][A-Za-z0-9_]*)\??\.data\??\.result\b/g)) {
       const query = queryByName.get(m[1]!);
       if (!query || query.kind !== 'servicenow') continue;
+      // Transformations replace query.data and may deliberately add a result field.
+      if (isTruthyBinding(propVal(recordValue(query.options), 'enableTransformation'))) continue;
       bad.add(m[1]!);
     }
     for (const name of bad) {

--- a/tests/datasourceCatalog.test.ts
+++ b/tests/datasourceCatalog.test.ts
@@ -115,6 +115,17 @@ describe('datasource query catalog', () => {
     });
   });
 
+  it('distinguishes ServiceNow MCP workflow results from REST flow outputs', () => {
+    const workflow = selectDatasourceQuerySchema('servicenow', { operation: 'invoke_workflow' }) as any;
+    const flow = selectDatasourceQuerySchema('servicenow', { operation: 'trigger_flow' }) as any;
+
+    expect(workflow.response).toMatchObject({ type: 'object', status: 'known' });
+    expect(workflow.response.description).toContain('data.content');
+    expect(workflow.response.description).toContain('data.structuredContent');
+    expect(workflow.response.description).toContain('does not parse text blocks or expose outputs at data.outputs');
+    expect(flow.response.description).toContain('outputs are at queries.<q>.data.outputs');
+  });
+
   it('gives every generated operation an honest response status', () => {
     for (const source of getDatasourceCatalog()) {
       const schema = getDatasourceQuerySchema(source.kind)!;

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1285,6 +1285,20 @@ describe('validateAppStructure', () => {
     }
   });
 
+  it('rejects a .data.result binding on a ServiceNow query, the Luna Halvard case', () => {
+    const withBinding = (binding: string, kind: string): AppSummary => ({
+      ...base,
+      pages: [{ id: 'p1', name: 'Home', components: [{ ...base.pages[0]!.components[0]!, properties: { ...base.pages[0]!.components[0]!.properties, data: { value: binding } } }] }],
+      queries: [{ id: 'q1', name: 'incidents', kind, options: { operation: 'list_records', runOnPageLoad: true } }],
+    });
+    const wrong = validateAppStructure(withBinding('{{queries.incidents.data && queries.incidents.data.result ? queries.incidents.data.result : []}}', 'servicenow'));
+    expect(wrong.errors.filter((e) => e.includes('unwraps the REST result envelope'))).toHaveLength(1);
+    expect(validateAppStructure(withBinding('{{queries.incidents?.data?.result ?? []}}', 'servicenow')).errors.filter((e) => e.includes('unwraps the REST'))).toHaveLength(1);
+    for (const ok of [withBinding('{{queries.incidents.data}}', 'servicenow'), withBinding('{{queries.incidents.data.result}}', 'restapi')]) {
+      expect(validateAppStructure(ok).errors.filter((e) => e.includes('unwraps the REST'))).toEqual([]);
+    }
+  });
+
   it('rejects a Chart bound straight to non-x/y query rows and accepts RunJS or x/y SQL sources', () => {
     const withChart = (binding: string, query: Record<string, unknown>): AppSummary => ({
       ...base,

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -1299,6 +1299,33 @@ describe('validateAppStructure', () => {
     }
   });
 
+  it.each([
+    { transformationLanguage: 'javascript', transformations: { javascript: 'return { result: data };' } },
+    { transformationLanguage: 'python', transformations: { python: 'return {"result": data}' } },
+    { transformationLanguage: 'javascript', transformation: 'return { result: data };' },
+  ])('allows transformed ServiceNow result bindings only while the transformation is enabled: %j', (transformation) => {
+    const summary: AppSummary = {
+      ...base,
+      pages: [{
+        id: 'p1', name: 'Home', components: [{
+          ...base.pages[0]!.components[0]!,
+          properties: {
+            ...base.pages[0]!.components[0]!.properties,
+            data: { value: '{{queries.loadHardware.data.result}}' },
+          },
+        }],
+      }],
+      queries: [{
+        id: 'q1', name: 'loadHardware', kind: 'servicenow',
+        options: { operation: 'list_records', runOnPageLoad: true, ...transformation, enableTransformation: true },
+      }],
+    };
+    expect(validateAppStructure(summary).errors.filter((e) => e.includes('unwraps the REST'))).toEqual([]);
+
+    summary.queries[0]!.options = { ...(summary.queries[0]!.options as Record<string, unknown>), enableTransformation: false };
+    expect(validateAppStructure(summary).errors.filter((e) => e.includes('unwraps the REST'))).toHaveLength(1);
+  });
+
   it('rejects a Chart bound straight to non-x/y query rows and accepts RunJS or x/y SQL sources', () => {
     const withChart = (binding: string, query: Record<string, unknown>): AppSummary => ({
       ...base,


### PR DESCRIPTION
## What

- Adds a curated response contract for every ServiceNow operation to `data/datasource-contract-overrides.json`: records come back as the array itself (the plugin unwraps ServiceNow's REST `result` envelope), single records as the object, aggregate as the stats object, flows with `data.outputs`. `list_records` also gets notes on binding and on reference fields being `{ display_value, link }` objects when `sysparm_display_value=true`.
- Adds a `validateAppStructure` error for any component that binds to `queries.<q>.data.result` when `<q>` is a ServiceNow query, with a test.
- Regenerates the datasource catalog and coverage, and rebuilds the bundle.

## Why

In the 2026-09-07 model-guide benchmark (Halvard incident desk on a connected ServiceNow instance), three of eleven models bound every incident list to `data.result` from memory of the raw REST API and rendered empty queues, although their queries returned 16 to 40 incidents. The catalog told them "this plugin does not publish a stable response contract".

## Verification

- `npx vitest run`: 942 tests pass.
- Halvard rerun on all eleven models with this change: zero `.data.result` bindings across the eleven apps, down from three. The lint did not need to fire; the contract alone was enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)