### PR TITLE
feat: add create_render_session for browser-based render checks

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -35702,6 +35702,39 @@ function createClient(auth, config2) {
       datasources_url: datasourceManagementUrl(orgSlug)
     };
   }
+  async function createAppScopedSession(appId, email3, expiryMinutes) {
+    const accessToken = process.env.EXTERNAL_API_ACCESS_TOKEN?.trim();
+    if (!accessToken) {
+      throw new Error("EXTERNAL_API_ACCESS_TOKEN is not configured on this MCP server, so a render session cannot be minted. Skip the render check rather than reporting the app as broken.");
+    }
+    const post = async (path, body, headers) => {
+      const res = await fetch(`${config2.apiUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...headers ?? {} },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) {
+        throw new Error(`ToolJet ${path} failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+      }
+      return await res.json();
+    };
+    const created = await post("/api/ext/users/personal-access-token", { email: email3, appSlug: appId, patExpiry: expiryMinutes, sessionExpiry: expiryMinutes }, { Authorization: `Basic ${accessToken}` });
+    const pat = created.personalAccessToken;
+    if (typeof pat !== "string" || !pat) {
+      throw new Error("ToolJet did not return a personal access token for the render session.");
+    }
+    const session = await post("/api/ext/users/session", { appId, accessToken: pat });
+    const token = session.signedPat;
+    if (typeof token !== "string" || !token) {
+      throw new Error("ToolJet did not return a session for the render personal access token.");
+    }
+    const orgSlug = await auth.getOrganizationSlug();
+    return {
+      token,
+      expires_in_minutes: expiryMinutes,
+      url: `${config2.appUrl}/${orgSlug}/apps/${appId}`
+    };
+  }
   async function renameApp(appId, versionId, name) {
     const res = await auth.authedFetch(`/api/apps/${appId}`, {
       method: "PUT",
@@ -36505,6 +36538,7 @@ function createClient(auth, config2) {
     updateWorkspaceUser,
     setWorkspaceUserArchived,
     createApp,
+    createAppScopedSession,
     renameApp,
     getApp,
     getAppSummary,
@@ -38502,6 +38536,32 @@ function getComponentTool(client) {
     async handler(args) {
       try {
         const result = await client.getComponent(args.app_id, args.component_id);
+        return ok(result);
+      } catch (err) {
+        return fail(err);
+      }
+    }
+  };
+}
+
+// dist/tools/createRenderSession.js
+function createRenderSessionTool(client) {
+  return {
+    name: "create_render_session",
+    title: "Create Render Session",
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true
+    },
+    description: "Mint a SHORT-LIVED browser session scoped to one app, for loading it in a headless browser to check how it rendered. Returns { token, expires_in_minutes, url } \u2014 set `token` as the tj_auth_token cookie (or header) and navigate to `url`. The token is scoped to this app alone and cannot be used to read or write anything else. Requires EXTERNAL_API_ACCESS_TOKEN to be configured on this server; without it the call fails and the caller should skip its render check rather than treat the app as broken. Not a general-purpose credential: do not persist it.",
+    inputSchema: {
+      app_id: external_exports.string(),
+      email: external_exports.string().describe("The user the session belongs to; the render is seen as they would see it."),
+      expiry_minutes: external_exports.number().int().min(1).max(60).optional()
+    },
+    async handler(args) {
+      try {
+        const result = await client.createAppScopedSession(args.app_id, args.email, args.expiry_minutes ?? 15);
         return ok(result);
       } catch (err) {
         return fail(err);
@@ -43732,6 +43792,7 @@ function registerTools(server, client, runtime = runtimeFreshness) {
     getAppSummaryTool(client),
     getComponentTool(client),
     validateAppTool(client),
+    createRenderSessionTool(client),
     lintAppSpecTool(client),
     applyAppPhaseTool(client),
     addPageTool(client),

--- a/src/tooljetClient.ts
+++ b/src/tooljetClient.ts
@@ -476,6 +476,12 @@ export interface ToolJetClient {
   updateWorkspaceUser(organizationUserId: string, params: UpdateWorkspaceUserParams): Promise<void>;
   setWorkspaceUserArchived(organizationUserId: string, archived: boolean): Promise<void>;
   createApp(name: string): Promise<CreateAppResult>;
+  /** A short-lived, app-scoped browser session. See createAppScopedSession for why it exists. */
+  createAppScopedSession(
+    appId: string,
+    email: string,
+    expiryMinutes: number
+  ): Promise<{ token: string; expires_in_minutes: number; url: string }>;
   renameApp(appId: string, versionId: string, name: string): Promise<void>;
   getApp(appId: string): Promise<any>;
   getAppSummary(appId: string): Promise<AppSummary>;
@@ -1068,6 +1074,68 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
       editor_url: editorUrl,
       viewer_url: viewerUrl,
       datasources_url: datasourceManagementUrl(orgSlug),
+    };
+  }
+
+  /* A browser-usable session for ONE app.
+   *
+   * Two calls against ToolJet's external API: create an app-scoped PAT, then trade it for a session.
+   * The result is signed by the same signer as a cookie login, so a browser accepts it as
+   * tj_auth_token — unlike the workspace session this server builds with, which is PAT-derived and
+   * which PatScopeInterceptor bars from the endpoints the frontend needs to boot.
+   *
+   * EXTERNAL_API_ACCESS_TOKEN is an instance-wide secret (it can mint for any user and any app), so
+   * it is read here, in the deployment that already owns it, and never handed to a caller. What
+   * leaves this function is only a short-lived token for the one app that was asked about.
+   */
+  async function createAppScopedSession(
+    appId: string,
+    email: string,
+    expiryMinutes: number
+  ): Promise<{ token: string; expires_in_minutes: number; url: string }> {
+    const accessToken = process.env.EXTERNAL_API_ACCESS_TOKEN?.trim();
+    if (!accessToken) {
+      throw new Error(
+        'EXTERNAL_API_ACCESS_TOKEN is not configured on this MCP server, so a render session cannot ' +
+          'be minted. Skip the render check rather than reporting the app as broken.'
+      );
+    }
+
+    const post = async (path: string, body: unknown, headers?: Record<string, string>) => {
+      const res = await fetch(`${config.apiUrl}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(headers ?? {}) },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(`ToolJet ${path} failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+      }
+      return (await res.json()) as Record<string, unknown>;
+    };
+
+    const created = await post(
+      '/api/ext/users/personal-access-token',
+      { email, appSlug: appId, patExpiry: expiryMinutes, sessionExpiry: expiryMinutes },
+      { Authorization: `Basic ${accessToken}` }
+    );
+    const pat = created.personalAccessToken;
+    if (typeof pat !== 'string' || !pat) {
+      throw new Error('ToolJet did not return a personal access token for the render session.');
+    }
+
+    const session = await post('/api/ext/users/session', { appId, accessToken: pat });
+    const token = session.signedPat;
+    if (typeof token !== 'string' || !token) {
+      throw new Error('ToolJet did not return a session for the render personal access token.');
+    }
+
+    // The editor route, not the viewer one: /applications/<id> serves an unreleased app as
+    // "app not available", while the editor renders the current version.
+    const orgSlug = await auth.getOrganizationSlug();
+    return {
+      token,
+      expires_in_minutes: expiryMinutes,
+      url: `${config.appUrl}/${orgSlug}/apps/${appId}`,
     };
   }
 
@@ -2149,6 +2217,7 @@ export function createClient(auth: Auth, config: Config): ToolJetClient {
     updateWorkspaceUser,
     setWorkspaceUserArchived,
     createApp,
+    createAppScopedSession,
     renameApp,
     getApp,
     getAppSummary,

--- a/src/tools/createRenderSession.ts
+++ b/src/tools/createRenderSession.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import type { ToolJetClient } from '../tooljetClient.js';
+import { ok, fail, type ToolDef } from './types.js';
+
+/* A browser-usable credential for ONE app.
+ *
+ * The session this server builds with is PAT-derived (isPATLogin), and PatScopeInterceptor bars such
+ * sessions from the endpoints the frontend needs to boot: /api/session answers 403 and the page
+ * redirects to login. An APP-scoped PAT is the documented exception — its session carries
+ * scope:"App" + appId, which becomes user.patAppId, and the interceptor lets those straight through
+ * because "the embed viewer legitimately needs far more surface than an automation client".
+ *
+ * Minting lives HERE rather than in the calling agent because it needs EXTERNAL_API_ACCESS_TOKEN —
+ * an instance-wide secret that can mint a token for any user and any app. That belongs in the
+ * deployment that already owns it, next to ToolJet, not in a hosted agent's environment. The caller
+ * receives only the narrow result: a short-lived JWT for one app.
+ */
+export function createRenderSessionTool(client: ToolJetClient): ToolDef {
+  return {
+    name: 'create_render_session',
+    title: 'Create Render Session',
+    annotations: {
+      readOnlyHint: false,
+      openWorldHint: true,
+    },
+    description:
+      'Mint a SHORT-LIVED browser session scoped to one app, for loading it in a headless browser to ' +
+      'check how it rendered. Returns { token, expires_in_minutes, url } — set `token` as the ' +
+      'tj_auth_token cookie (or header) and navigate to `url`. The token is scoped to this app alone ' +
+      'and cannot be used to read or write anything else. Requires EXTERNAL_API_ACCESS_TOKEN to be ' +
+      'configured on this server; without it the call fails and the caller should skip its render ' +
+      'check rather than treat the app as broken. Not a general-purpose credential: do not persist it.',
+    inputSchema: {
+      app_id: z.string(),
+      email: z.string().describe('The user the session belongs to; the render is seen as they would see it.'),
+      expiry_minutes: z.number().int().min(1).max(60).optional(),
+    },
+    async handler(args: { app_id: string; email: string; expiry_minutes?: number }) {
+      try {
+        const result = await client.createAppScopedSession(args.app_id, args.email, args.expiry_minutes ?? 15);
+        return ok(result);
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -26,6 +26,7 @@ import { generateFormSchemaTool } from './generateFormSchema.js';
 import { getAppTool } from './getApp.js';
 import { getAppSummaryTool } from './getAppSummary.js';
 import { getComponentTool } from './getComponent.js';
+import { createRenderSessionTool } from './createRenderSession.js';
 import { validateAppTool } from './validateApp.js';
 import { lintAppSpecTool } from './lintAppSpec.js';
 import { applyAppPhaseTool } from './applyAppPhase.js';
@@ -115,6 +116,7 @@ export function registerTools(
     getAppSummaryTool(client),
     getComponentTool(client),
     validateAppTool(client),
+    createRenderSessionTool(client),
     lintAppSpecTool(client),
     applyAppPhaseTool(client),
     addPageTool(client),


### PR DESCRIPTION
Mints a short-lived, app-scoped session an agent can use to load one app in a headless browser. The workspace session callers build with is PAT-derived and PatScopeInterceptor bars it from the endpoints the frontend needs to boot.

Minting lives here because it needs EXTERNAL_API_ACCESS_TOKEN, an instance-wide secret that belongs beside ToolJet rather than in a hosted agent's environment. Callers receive only a token for the one app they asked about.