### PR TITLE
Fix/influxdb read classifier

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -48140,6 +48140,102 @@ function assessOpenapi(options2, datasourceId) {
     ...identity
   };
 }
+var INFLUX_ROW_READS = /* @__PURE__ */ new Set(["query_data"]);
+var INFLUX_METADATA_READS = /* @__PURE__ */ new Set([
+  "list_buckets",
+  "retrieve_bucket",
+  "analyze_flux_query",
+  "abstract_syntax_tree",
+  "query_suggestions",
+  "query_suggestions_for_branching"
+]);
+var FLUX_WRITE_CALL = /(^|[^A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)?(?:wideTo|to)\s*\(/;
+var FLUX_EGRESS_PACKAGES = [
+  "sql",
+  "kafka",
+  "mqtt",
+  "http",
+  "slack",
+  "pagerduty",
+  "discord",
+  "teams",
+  "telegram",
+  "bigpanda",
+  "opsgenie",
+  "sensu",
+  "servicenow",
+  "victorops",
+  "webexteams",
+  "zenoss",
+  "monitor",
+  "influxdata/influxdb/secrets",
+  "influxdata/influxdb/tasks"
+];
+var FLUX_EGRESS_IMPORT = new RegExp(String.raw`(^|\n)\s*import\s+(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"(?:` + FLUX_EGRESS_PACKAGES.map((name) => name.replace(/\//g, String.raw`\/`)).join("|") + String.raw`)"`);
+var FLUX_LIMIT = /(^|[^A-Za-z0-9_.])limit\s*\(\s*n\s*:\s*(\d+)/;
+function assessInflux(options2, datasourceId) {
+  const identity = { datasourceKind: "influxdb", ...datasourceId ? { datasourceId } : {} };
+  const operation = typeof options2.operation === "string" ? options2.operation.toLowerCase() : void 0;
+  const refuse = (reason) => ({
+    provenRead: false,
+    directSafe: false,
+    countOnly: false,
+    selectStar: false,
+    requiresCountPreflight: false,
+    reason,
+    ...identity
+  });
+  if (!operation)
+    return refuse("InfluxDB query has no operation.");
+  if (!INFLUX_ROW_READS.has(operation) && !INFLUX_METADATA_READS.has(operation)) {
+    return refuse(`InfluxDB operation ${operation} is not a read; it can change InfluxDB state.`);
+  }
+  const remote = {
+    provenRead: true,
+    directSafe: false,
+    selectStar: false,
+    requiresCountPreflight: false,
+    requiresRemoteReadConfirmation: true,
+    ...identity
+  };
+  if (INFLUX_METADATA_READS.has(operation)) {
+    return {
+      ...remote,
+      countOnly: false,
+      reason: `InfluxDB ${operation} reads remote metadata without executing a query.`
+    };
+  }
+  const body = typeof options2.body === "string" ? options2.body : "";
+  if (!body.trim())
+    return refuse("InfluxDB query_data has no Flux body to classify.");
+  if (FLUX_WRITE_CALL.test(body)) {
+    return refuse("InfluxDB query_data body calls to()/wideTo(), which writes points or rows out of the query; that is not a read.");
+  }
+  const egress = body.match(FLUX_EGRESS_IMPORT);
+  if (egress) {
+    return refuse(`InfluxDB query_data body imports ${egress[0].trim()}, which can send data out of InfluxDB or read secrets; that is not a read.`);
+  }
+  const bucket = body.match(/from\s*\(\s*bucket\s*:\s*"([^"]+)"/)?.[1];
+  const source2 = bucket ? { kind: "remote_endpoint", value: `influxdb:${bucket}` } : void 0;
+  const bounded = { ...remote, countOnly: false, ...source2 ? { source: source2 } : {} };
+  const maxRows = staticPositiveInteger(body.match(FLUX_LIMIT)?.[2]);
+  if (maxRows === void 0) {
+    return {
+      ...bounded,
+      requiresCountPreflight: true,
+      reason: "InfluxDB Flux query has no static limit(n:), so the number of points it returns cannot be bounded."
+    };
+  }
+  if (maxRows > LARGE_READ_ROW_THRESHOLD) {
+    return {
+      ...bounded,
+      requiresCountPreflight: true,
+      maxRows,
+      reason: `InfluxDB Flux query can return up to ${maxRows} points, above the ${LARGE_READ_ROW_THRESHOLD}-row safety threshold.`
+    };
+  }
+  return { ...bounded, maxRows, reason: "InfluxDB query_data reads remote time-series data." };
+}
 function assessRestGet(options2, datasourceId) {
   const identity = { datasourceKind: "restapi", ...datasourceId ? { datasourceId } : {} };
   const method = typeof options2.method === "string" ? options2.method.toLowerCase() : void 0;
@@ -48508,6 +48604,8 @@ function assessQueryRead(query) {
     return assessOpenapi(options2, datasourceId);
   if (kind === "servicenow")
     return assessServiceNow(options2, datasourceId);
+  if (kind === "influxdb")
+    return assessInflux(options2, datasourceId);
   if (kind === "supabase")
     return assessSupabase(options2, datasourceId);
   if (kind === "tooljetdb") {
@@ -48712,9 +48810,56 @@ function interpolatedSqlBindingIssues(sql) {
     }
   ];
 }
+function transformationWarnings(options2) {
+  const warnings = [];
+  const bag = isObject2(options2.transformations) ? options2.transformations : void 0;
+  const languages = bag ? Object.keys(bag).filter((key) => key === "javascript" || key === "python") : [];
+  const hasCode = languages.length > 0 || typeof options2.transformation === "string" && options2.transformation.trim() !== "";
+  if (!hasCode)
+    return warnings;
+  const enabled = isTruthyStatic(options2.enableTransformation);
+  const language = typeof options2.transformationLanguage === "string" ? options2.transformationLanguage : void 0;
+  if (!enabled) {
+    warnings.push({
+      code: "transformation_not_enabled",
+      path: "enableTransformation",
+      message: "A transformation is supplied but enableTransformation is not true, so ToolJet saves the code and never runs it. Set enableTransformation: true and transformationLanguage to the language the code is written in."
+    });
+  }
+  if (!language) {
+    warnings.push({
+      code: "transformation_language_missing",
+      path: "transformationLanguage",
+      message: `A transformation is supplied without transformationLanguage, so ToolJet cannot tell how to run it. Set it to ${languages.length === 1 ? `"${languages[0]}"` : '"javascript" or "python"'}.`
+    });
+  } else if (languages.length > 0 && !languages.includes(language)) {
+    warnings.push({
+      code: "transformation_language_mismatch",
+      path: "transformationLanguage",
+      message: `transformationLanguage is "${language}" but the code is under transformations.${languages.join("/")}. ToolJet runs the entry matching transformationLanguage, so the supplied code is ignored.`
+    });
+  }
+  return warnings;
+}
+function influxTransformWarnings(kind, options2) {
+  if (kind !== "influxdb")
+    return [];
+  const operation = typeof options2.operation === "string" ? options2.operation.toLowerCase() : void 0;
+  if (operation !== "query_data")
+    return [];
+  if (isTruthyStatic(options2.enableTransformation))
+    return [];
+  return [{
+    code: "influx_raw_csv_response",
+    path: "enableTransformation",
+    message: 'InfluxDB query_data returns annotated CSV as a single raw string, not rows. Bound directly, a Table renders nothing. Add a transformation that parses the CSV into an array of row objects (skip the #datatype/#group/#default annotation lines and the empty leading columns), with enableTransformation: true and transformationLanguage: "javascript".'
+  }];
+}
 function validateQueryOptions(kind, options2) {
   const errors = [];
   const warnings = tableStateWarnings(options2);
+  warnings.push(...transformationWarnings(options2));
+  warnings.push(...influxTransformWarnings(kind, options2));
   if (typeof options2.query === "string") {
     errors.push(...unquotedSqlBindingIssues(options2.query));
     warnings.push(...interpolatedSqlBindingIssues(options2.query));

--- a/src/queryExecutionSafety.ts
+++ b/src/queryExecutionSafety.ts
@@ -168,6 +168,88 @@ function assessOpenapi(options: Record<string, unknown>, datasourceId?: string):
   };
 }
 
+/* InfluxDB's v2 API, split by effect.
+
+   Without this, every InfluxDB query fell through to "no proven read classifier" and was refused
+   before execution — the same failure mode ServiceNow had above. Measured on a real 2-page build
+   (thread f4e3a7da): all three Flux queries were refused on every turn, so the agent never saw a
+   response and shipped a guessed transformation it re-guessed twice more.
+
+   Reads are proven but never directSafe: they cross into a remote system and can return an
+   unbounded series. */
+const INFLUX_ROW_READS = new Set(['query_data']);
+const INFLUX_METADATA_READS = new Set([
+  'list_buckets',
+  'retrieve_bucket',
+  'analyze_flux_query',
+  'abstract_syntax_tree',
+  'query_suggestions',
+  'query_suggestions_for_branching',
+]);
+
+/* Flux is not read-only. `to()` and `experimental.to()` write points back into a bucket, so a
+   query_data body carrying one is a write wearing a read's operation name. */
+const FLUX_WRITE_CALL = /(^|[^A-Za-z0-9_.])(?:experimental\.)?to\s*\(/;
+
+/* A Flux read is bounded by an explicit `limit(n:)`; a bare `range()` over a busy measurement can
+   return millions of points. */
+const FLUX_LIMIT = /(^|[^A-Za-z0-9_.])limit\s*\(\s*n\s*:\s*(\d+)/;
+
+function assessInflux(options: Record<string, unknown>, datasourceId?: string): QueryReadAssessment {
+  const identity = { datasourceKind: 'influxdb', ...(datasourceId ? { datasourceId } : {}) };
+  const operation = typeof options.operation === 'string' ? options.operation.toLowerCase() : undefined;
+  const refuse = (reason: string): QueryReadAssessment => ({
+    provenRead: false, directSafe: false, countOnly: false, selectStar: false,
+    requiresCountPreflight: false, reason, ...identity,
+  });
+
+  if (!operation) return refuse('InfluxDB query has no operation.');
+
+  // write appends points; create/update/delete_bucket change retention and can destroy series.
+  if (!INFLUX_ROW_READS.has(operation) && !INFLUX_METADATA_READS.has(operation)) {
+    return refuse(`InfluxDB operation ${operation} is not a read; it can change InfluxDB state.`);
+  }
+
+  const remote = {
+    provenRead: true as const, directSafe: false as const, selectStar: false as const,
+    requiresCountPreflight: false as const, requiresRemoteReadConfirmation: true as const,
+    ...identity,
+  };
+
+  if (INFLUX_METADATA_READS.has(operation)) {
+    return { ...remote, countOnly: false,
+      reason: `InfluxDB ${operation} reads remote metadata without executing a query.` };
+  }
+
+  // query_data: the Flux script is the query, and it decides both effect and size.
+  const body = typeof options.body === 'string' ? options.body : '';
+  if (!body.trim()) return refuse('InfluxDB query_data has no Flux body to classify.');
+  if (FLUX_WRITE_CALL.test(body)) {
+    return refuse('InfluxDB query_data body calls to(), which writes points back into a bucket; that is not a read.');
+  }
+
+  const bucket = body.match(/from\s*\(\s*bucket\s*:\s*"([^"]+)"/)?.[1];
+  const source = bucket
+    ? ({ kind: 'remote_endpoint', value: `influxdb:${bucket}` } as QueryReadAssessment['source'])
+    : undefined;
+  const bounded = { ...remote, countOnly: false, ...(source ? { source } : {}) };
+
+  const maxRows = staticPositiveInteger(body.match(FLUX_LIMIT)?.[2]);
+  if (maxRows === undefined) {
+    return {
+      ...bounded, requiresCountPreflight: true,
+      reason: 'InfluxDB Flux query has no static limit(n:), so the number of points it returns cannot be bounded.',
+    };
+  }
+  if (maxRows > LARGE_READ_ROW_THRESHOLD) {
+    return {
+      ...bounded, requiresCountPreflight: true, maxRows,
+      reason: `InfluxDB Flux query can return up to ${maxRows} points, above the ${LARGE_READ_ROW_THRESHOLD}-row safety threshold.`,
+    };
+  }
+  return { ...bounded, maxRows, reason: 'InfluxDB query_data reads remote time-series data.' };
+}
+
 function assessRestGet(options: Record<string, unknown>, datasourceId?: string): QueryReadAssessment {
   const identity = { datasourceKind: 'restapi', ...(datasourceId ? { datasourceId } : {}) };
   const method = typeof options.method === 'string' ? options.method.toLowerCase() : undefined;
@@ -428,6 +510,8 @@ export function assessQueryRead(query: QuerySummary): QueryReadAssessment {
   if (kind === 'openapi') return assessOpenapi(options, datasourceId);
 
   if (kind === 'servicenow') return assessServiceNow(options, datasourceId);
+
+  if (kind === 'influxdb') return assessInflux(options, datasourceId);
 
   if (kind === 'supabase') return assessSupabase(options, datasourceId);
 

--- a/src/queryExecutionSafety.ts
+++ b/src/queryExecutionSafety.ts
@@ -187,9 +187,28 @@ const INFLUX_METADATA_READS = new Set([
   'query_suggestions_for_branching',
 ]);
 
-/* Flux is not read-only. `to()` and `experimental.to()` write points back into a bucket, so a
-   query_data body carrying one is a write wearing a read's operation name. */
-const FLUX_WRITE_CALL = /(^|[^A-Za-z0-9_.])(?:experimental\.)?to\s*\(/;
+/* Flux is not read-only, and the writers are a family, not two names: `to()`, `experimental.to()`,
+   `experimental.wideTo()`, `sql.to()`, `kafka.to()`, `mqtt.to()`. The package qualifier can be any
+   identifier, so match a qualified OR bare call rather than naming the packages — a denylist of
+   package names goes stale the moment Flux adds another writer.
+
+   Matching `<anything>.to(` is safe here because Flux records have no methods: you cannot call a
+   field, so a qualified `.to(` is always a package function, never user data. */
+const FLUX_WRITE_CALL = /(^|[^A-Za-z0-9_])(?:[A-Za-z_][A-Za-z0-9_]*\s*\.\s*)?(?:wideTo|to)\s*\(/;
+
+/* The other half of the family sends data somewhere else, or pulls secrets into the result. None of
+   it belongs in a query run to check a build. Flux requires an explicit `import` for every one of
+   these packages, so gate on the import: that catches the call however it is written or aliased. */
+const FLUX_EGRESS_PACKAGES = [
+  'sql', 'kafka', 'mqtt', 'http', 'slack', 'pagerduty', 'discord', 'teams', 'telegram',
+  'bigpanda', 'opsgenie', 'sensu', 'servicenow', 'victorops', 'webexteams', 'zenoss', 'monitor',
+  'influxdata/influxdb/secrets', 'influxdata/influxdb/tasks',
+];
+const FLUX_EGRESS_IMPORT = new RegExp(
+  String.raw`(^|\n)\s*import\s+(?:[A-Za-z_][A-Za-z0-9_]*\s+)?"(?:` +
+    FLUX_EGRESS_PACKAGES.map((name) => name.replace(/\//g, String.raw`\/`)).join('|') +
+    String.raw`)"`
+);
 
 /* A Flux read is bounded by an explicit `limit(n:)`; a bare `range()` over a busy measurement can
    return millions of points. */
@@ -225,7 +244,16 @@ function assessInflux(options: Record<string, unknown>, datasourceId?: string): 
   const body = typeof options.body === 'string' ? options.body : '';
   if (!body.trim()) return refuse('InfluxDB query_data has no Flux body to classify.');
   if (FLUX_WRITE_CALL.test(body)) {
-    return refuse('InfluxDB query_data body calls to(), which writes points back into a bucket; that is not a read.');
+    return refuse(
+      'InfluxDB query_data body calls to()/wideTo(), which writes points or rows out of the query; that is not a read.'
+    );
+  }
+  const egress = body.match(FLUX_EGRESS_IMPORT);
+  if (egress) {
+    return refuse(
+      `InfluxDB query_data body imports ${egress[0].trim()}, which can send data out of InfluxDB or read secrets; ` +
+        'that is not a read.'
+    );
   }
 
   const bucket = body.match(/from\s*\(\s*bucket\s*:\s*"([^"]+)"/)?.[1];

--- a/src/queryValidation.ts
+++ b/src/queryValidation.ts
@@ -219,9 +219,75 @@ function interpolatedSqlBindingIssues(sql: string): QueryValidationIssue[] {
   ];
 }
 
+/* A transformation is three fields, not one. `transformations` / `transformation` carries the code,
+   but ToolJet only runs it when `enableTransformation` is true and `transformationLanguage` names the
+   language the code is under. Writing the code alone saves a transformation that never executes, and
+   the app looks like the transformation is wrong rather than off. Observed on a real build (thread
+   f4e3a7da): three turns of rewriting a transformation that was never enabled. */
+function transformationWarnings(options: Record<string, unknown>): QueryValidationIssue[] {
+  const warnings: QueryValidationIssue[] = [];
+  const bag = isObject(options.transformations) ? options.transformations : undefined;
+  const languages: string[] = bag ? Object.keys(bag).filter((key) => key === 'javascript' || key === 'python') : [];
+  const hasCode = languages.length > 0
+    || (typeof options.transformation === 'string' && options.transformation.trim() !== '');
+  if (!hasCode) return warnings;
+
+  const enabled = isTruthyStatic(options.enableTransformation);
+  const language = typeof options.transformationLanguage === 'string' ? options.transformationLanguage : undefined;
+  if (!enabled) {
+    warnings.push({
+      code: 'transformation_not_enabled',
+      path: 'enableTransformation',
+      message:
+        'A transformation is supplied but enableTransformation is not true, so ToolJet saves the code and never runs it. ' +
+        'Set enableTransformation: true and transformationLanguage to the language the code is written in.',
+    });
+  }
+  if (!language) {
+    warnings.push({
+      code: 'transformation_language_missing',
+      path: 'transformationLanguage',
+      message:
+        'A transformation is supplied without transformationLanguage, so ToolJet cannot tell how to run it. ' +
+        `Set it to ${languages.length === 1 ? `"${languages[0]}"` : '"javascript" or "python"'}.`,
+    });
+  } else if (languages.length > 0 && !languages.includes(language)) {
+    warnings.push({
+      code: 'transformation_language_mismatch',
+      path: 'transformationLanguage',
+      message:
+        `transformationLanguage is "${language}" but the code is under transformations.${languages.join('/')}. ` +
+        'ToolJet runs the entry matching transformationLanguage, so the supplied code is ignored.',
+    });
+  }
+  return warnings;
+}
+
+/* InfluxDB query_data returns the raw /api/v2/query response body: annotated CSV as one string, not
+   rows. Every component that expects rows — Table above all — needs a transformation to parse it.
+   The MCP client inferred this; the AI builder did not, and needed telling twice (reported build,
+   90+ minutes). Say it at authoring time instead. */
+function influxTransformWarnings(kind: string, options: Record<string, unknown>): QueryValidationIssue[] {
+  if (kind !== 'influxdb') return [];
+  const operation = typeof options.operation === 'string' ? options.operation.toLowerCase() : undefined;
+  if (operation !== 'query_data') return [];
+  if (isTruthyStatic(options.enableTransformation)) return [];
+  return [{
+    code: 'influx_raw_csv_response',
+    path: 'enableTransformation',
+    message:
+      'InfluxDB query_data returns annotated CSV as a single raw string, not rows. Bound directly, a Table renders ' +
+      'nothing. Add a transformation that parses the CSV into an array of row objects (skip the #datatype/#group/' +
+      '#default annotation lines and the empty leading columns), with enableTransformation: true and ' +
+      'transformationLanguage: "javascript".',
+  }];
+}
+
 export function validateQueryOptions(kind: string, options: Record<string, unknown>): QueryValidationResult {
   const errors: QueryValidationIssue[] = [];
   const warnings: QueryValidationIssue[] = tableStateWarnings(options);
+  warnings.push(...transformationWarnings(options));
+  warnings.push(...influxTransformWarnings(kind, options));
   if (typeof options.query === "string") {
     errors.push(...unquotedSqlBindingIssues(options.query));
     warnings.push(...interpolatedSqlBindingIssues(options.query));

--- a/tests/influxReadSafety.test.ts
+++ b/tests/influxReadSafety.test.ts
@@ -38,12 +38,43 @@ describe('InfluxDB read classification', () => {
     expect(a.maxRows).toBe(50000);
   });
 
-  it('refuses a Flux body that writes points back with to()', () => {
-    /* query_data is a read by operation name only; Flux to() writes into a bucket. */
-    const a = flux('from(bucket:"a") |> range(start:-1h) |> to(bucket:"b")');
-    expect(a.provenRead).toBe(false);
-    expect(a.reason).toMatch(/to\(\)/);
-    expect(flux('from(bucket:"a") |> range(start:-1h) |> experimental.to(bucket:"b")').provenRead).toBe(false);
+  it('refuses the whole Flux writer family, not just the two unqualified names', () => {
+    /* query_data is a read by operation name only. The writers are package-qualified, and an earlier
+       detector excluded a preceding dot to avoid matching user data — which let every qualified
+       writer through. Flux records have no methods, so a qualified `.to(` is always a package call. */
+    const writers = [
+      'to(bucket:"b")',
+      'experimental.to(bucket:"b")',
+      'experimental.wideTo(bucket:"b")',
+      'sql.to(driverName:"postgres", dataSourceName:"x", table:"t")',
+      'kafka.to(brokers:["b:9092"], topic:"t")',
+      'mqtt.to(broker:"tcp://b:1883")',
+    ];
+    for (const writer of writers) {
+      const a = flux(`from(bucket:"a") |> range(start:-1h) |> ${writer}`);
+      expect(a.provenRead, writer).toBe(false);
+    }
+  });
+
+  it('refuses a body importing a package that can send data out or read secrets', () => {
+    /* http.post/slack.message exfiltrate; secrets.get pulls credentials into the result. Each needs
+       an explicit import, so gating on the import catches the call however it is aliased. */
+    const egress = [
+      ['http', 'http.post(url:"http://example.com", data:bytes(v:"x"))'],
+      ['slack', 'slack.message(text:"x")'],
+      ['influxdata/influxdb/secrets', 'secrets.get(key:"token")'],
+    ];
+    for (const [pkg, call] of egress) {
+      const a = flux(`import "${pkg}"\nfrom(bucket:"a") |> range(start:-1h) |> ${call}`);
+      expect(a.provenRead, pkg).toBe(false);
+      expect(a.reason, pkg).toMatch(/send data out of InfluxDB or read secrets/);
+    }
+  });
+
+  it('still allows a read that imports a harmless package', () => {
+    /* The import gate must not refuse the helpers real read queries use. */
+    expect(flux('import "date"\nfrom(bucket:"t") |> range(start:-1h) |> limit(n:5)').provenRead).toBe(true);
+    expect(flux('import "influxdata/influxdb/schema"\nschema.fieldKeys(bucket:"t") |> limit(n:5)').provenRead).toBe(true);
   });
 
   it('does not mistake a column or function named *to* for a write', () => {

--- a/tests/influxReadSafety.test.ts
+++ b/tests/influxReadSafety.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { assessQueryRead } from '../src/queryExecutionSafety.js';
+import { validateQueryOptions } from '../src/queryValidation.js';
+
+/* A live 2-page build against a connected InfluxDB instance (thread f4e3a7da) took 90+ minutes and
+   169 MCP calls: every Flux read was refused with "Datasource kind influxdb has no proven read
+   classifier", so each query had to be verified through a browser round trip instead. */
+const influx = (options: Record<string, unknown>) =>
+  assessQueryRead({ kind: 'influxdb', data_source_id: 'ds-1', options } as never);
+
+const flux = (body: string) => influx({ operation: 'query_data', body });
+
+describe('InfluxDB read classification', () => {
+  it('proves a bounded Flux read', () => {
+    const a = flux('from(bucket:"telemetry") |> range(start:-1h) |> limit(n:100)');
+    expect(a.provenRead).toBe(true);
+    expect(a.maxRows).toBe(100);
+    expect(a.requiresCountPreflight).toBe(false);
+    expect(a.source).toEqual({ kind: 'remote_endpoint', value: 'influxdb:telemetry' });
+  });
+
+  it('never marks a remote read directSafe', () => {
+    const a = flux('from(bucket:"telemetry") |> range(start:-1h) |> limit(n:10)');
+    expect(a.directSafe).toBe(false);
+    expect(a.requiresRemoteReadConfirmation).toBe(true);
+  });
+
+  it('refuses to call an unlimited Flux query provably bounded', () => {
+    const a = flux('from(bucket:"telemetry") |> range(start:-30d)');
+    expect(a.provenRead).toBe(true);
+    expect(a.requiresCountPreflight).toBe(true);
+    expect(a.reason).toMatch(/no static limit/);
+  });
+
+  it('treats a limit above the threshold as needing a preflight', () => {
+    const a = flux('from(bucket:"telemetry") |> range(start:-30d) |> limit(n:50000)');
+    expect(a.requiresCountPreflight).toBe(true);
+    expect(a.maxRows).toBe(50000);
+  });
+
+  it('refuses a Flux body that writes points back with to()', () => {
+    /* query_data is a read by operation name only; Flux to() writes into a bucket. */
+    const a = flux('from(bucket:"a") |> range(start:-1h) |> to(bucket:"b")');
+    expect(a.provenRead).toBe(false);
+    expect(a.reason).toMatch(/to\(\)/);
+    expect(flux('from(bucket:"a") |> range(start:-1h) |> experimental.to(bucket:"b")').provenRead).toBe(false);
+  });
+
+  it('does not mistake a column or function named *to* for a write', () => {
+    expect(flux('from(bucket:"a") |> range(start:-1h) |> keep(columns:["into","_to"]) |> limit(n:5)').provenRead)
+      .toBe(true);
+  });
+
+  it('proves metadata reads without executing a query', () => {
+    expect(influx({ operation: 'list_buckets' }).provenRead).toBe(true);
+    expect(influx({ operation: 'analyze_flux_query', body: '{}' }).provenRead).toBe(true);
+  });
+
+  it('refuses every operation that changes InfluxDB state', () => {
+    for (const operation of ['write', 'create_bucket', 'update_bucket', 'delete_bucket']) {
+      const a = influx({ operation, body: 'x' });
+      expect(a.provenRead, operation).toBe(false);
+      expect(a.reason, operation).toMatch(/not a read/);
+    }
+  });
+
+  it('refuses a query_data with no Flux body to classify', () => {
+    expect(influx({ operation: 'query_data', body: '   ' }).provenRead).toBe(false);
+  });
+});
+
+describe('transformation configuration warnings', () => {
+  const codes = (kind: string, options: Record<string, unknown>) =>
+    validateQueryOptions(kind, options).warnings.map((w) => w.code);
+
+  it('warns when transformation code is supplied but never enabled', () => {
+    /* The reported failure: the transformation was saved and inert, so the table stayed empty and
+       the defect read as a wrong transformation rather than a disabled one. */
+    const c = codes('influxdb', {
+      operation: 'query_data',
+      body: 'from(bucket:"t") |> range(start:-1h) |> limit(n:10)',
+      transformations: { javascript: 'return data;' },
+    });
+    expect(c).toContain('transformation_not_enabled');
+    expect(c).toContain('transformation_language_missing');
+  });
+
+  it('stays quiet on a fully configured transformation', () => {
+    const c = codes('influxdb', {
+      operation: 'query_data',
+      body: 'from(bucket:"t") |> range(start:-1h) |> limit(n:10)',
+      transformations: { javascript: 'return data;' },
+      enableTransformation: true,
+      transformationLanguage: 'javascript',
+    });
+    expect(c).not.toContain('transformation_not_enabled');
+    expect(c).not.toContain('transformation_language_missing');
+    expect(c).not.toContain('influx_raw_csv_response');
+  });
+
+  it('flags code filed under a language the query does not run', () => {
+    const c = codes('postgresql', {
+      query: 'SELECT id FROM t LIMIT 1',
+      transformations: { python: 'return data' },
+      enableTransformation: true,
+      transformationLanguage: 'javascript',
+    });
+    expect(c).toContain('transformation_language_mismatch');
+  });
+
+  it('says nothing about transformations when no code was supplied', () => {
+    const c = codes('postgresql', { query: 'SELECT id FROM t LIMIT 1' });
+    expect(c.some((code) => code.startsWith('transformation'))).toBe(false);
+  });
+
+  it('tells the author that Influx query_data returns raw CSV, not rows', () => {
+    /* Reported: the MCP client inferred the transformation, the AI builder needed telling twice. */
+    const c = codes('influxdb', {
+      operation: 'query_data',
+      body: 'from(bucket:"t") |> range(start:-1h) |> limit(n:10)',
+    });
+    expect(c).toContain('influx_raw_csv_response');
+  });
+});


### PR DESCRIPTION
This PR makes InfluxDB datasources usable by the agent, extending the query-execution safety layer with a Flux-aware read classifier and catching transformation mistakes specific to Influx's response shape.

**InfluxDB read classification**

- Added `assessInflux` in `src/queryExecutionSafety.ts`: `influxdb` had no `assess*` branch, so every Flux query fell through to "no proven read classifier" and was refused before execution. Measured on a real 2-page build (thread `f4e3a7da`): all three Flux queries were refused on every turn, so the agent never saw a response and shipped a guessed transformation it re-guessed twice more
- `query_data` and the metadata operations (`list_buckets`, `retrieve_bucket`, `analyze_flux_query`, `abstract_syntax_tree`, `query_suggestions`, `query_suggestions_for_branching`) are proven remote reads requiring confirmation; they are never `directSafe`, since they cross into a remote system and can return an unbounded series
- `write` and the bucket mutations are refused — they change state and must not be run to see what happens
- **Flux is not read-only**: a `query_data` body calling `to()` or `experimental.to()` writes points back into a bucket, so it is treated as a write despite the operation name
- An explicit `limit(n:)` bounds the result; a bare `range()` over a busy measurement can return millions of points, so an unbounded read is flagged against the large-read threshold

**Transformation warnings**

- Warns when transformation code is saved without `enableTransformation` / `transformationLanguage`, or when the declared language does not match the code — the transformation is silently inert otherwise
- Warns when an Influx `query_data` feeds a component with no transformation: Influx returns annotated CSV as a raw string, not rows, so a table bound directly to it renders nothing

**Bundle**

- Regenerated `bundle/index.js`, which did not contain the classifier. The bundle is the artifact that ships, so without this the branch delivers none of the above

**Testing**

753 unit tests including 124 lines of new coverage in `tests/influxReadSafety.test.ts`; typecheck clean; bundle verified to boot and answer `initialize`.

